### PR TITLE
perf: benchmark polygon90 at million scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,27 +79,32 @@ c++ -O3 -DNDEBUG -std=c++11 boost_polygon90_pointarray_benchmark.cpp -o boost_po
 Run:
 
 ```sh
-./boost_polygon90_pointarray_benchmark 20000 3
+# Default is 1,000,000 LHS + 1,000,000 RHS polygons, one round.
+./boost_polygon90_pointarray_benchmark
+
+# Or override polygon count and rounds.
+./boost_polygon90_pointarray_benchmark 1000000 1
 ```
 
-Latest local benchmark on this machine, generated rectilinear data, 20,000 LHS +
-20,000 RHS polygons, best-of-3:
+Latest local benchmark on this machine, generated rectilinear data, 1,000,000
+LHS + 1,000,000 RHS polygons, best-of-1.  The mixed dataset is 70% rectangles,
+20% stair polygons, and 10% more complex comb polygons (~20 vertices each):
 
 - All rectangles, OR:
-  - generic tmp vector each polygon: 27.362 ms
-  - generic reusable scratch: 24.380 ms
-  - **rect fast path + scratch: 22.995 ms** ← fastest full PointArray pipeline
-  - prebuilt sets boolean+extract: 19.011 ms, excludes input conversion
-- 80% rectangles + 20% stair polygons, OR:
-  - generic tmp vector each polygon: 30.050 ms
-  - generic reusable scratch: 28.575 ms
-  - **rect fast path + scratch: 26.909 ms** ← fastest full PointArray pipeline
-  - prebuilt sets boolean+extract: 20.641 ms, excludes input conversion
+  - generic tmp vector each polygon: 1839.857 ms
+  - generic reusable scratch: 1733.341 ms
+  - **rect fast path + scratch: 1645.477 ms** ← fastest full PointArray pipeline
+  - prebuilt sets boolean+extract: 1532.403 ms, excludes input conversion
+- 70% rectangles + 20% stair + 10% complex comb polygons, OR:
+  - generic tmp vector each polygon: 2646.680 ms
+  - generic reusable scratch: 2531.862 ms
+  - **rect fast path + scratch: 2510.013 ms** ← fastest full PointArray pipeline
+  - prebuilt sets boolean+extract: 2195.477 ms, excludes input conversion
 - All rectangles, AND:
-  - generic tmp vector each polygon: 18.115 ms
-  - generic reusable scratch: 16.260 ms
-  - **rect fast path + scratch: 14.993 ms** ← fastest full PointArray pipeline
-  - prebuilt sets boolean+extract: 11.692 ms, excludes input conversion
+  - generic tmp vector each polygon: 1273.873 ms
+  - generic reusable scratch: 1201.126 ms
+  - **rect fast path + scratch: 1135.808 ms** ← fastest full PointArray pipeline
+  - prebuilt sets boolean+extract: 985.573 ms, excludes input conversion
 
 Conclusion: for `std::vector<PointArray>` input/output, the fastest measured
 full-pipeline implementation is `booleanRectFastPath`: rectangle detection +

--- a/boost_polygon90_pointarray_benchmark.cpp
+++ b/boost_polygon90_pointarray_benchmark.cpp
@@ -151,8 +151,38 @@ static PointArray makeStair(Coord x, Coord y, Coord step, int steps, Coord heigh
         p.push_back(Point(x + step * (i + 1), y + step * i));
         p.push_back(Point(x + step * (i + 1), y + step * (i + 1)));
     }
-    p.push_back(Point(x + step * steps, y + height));
+    if (p.back().y != y + height) {
+        p.push_back(Point(x + step * steps, y + height));
+    }
     p.push_back(Point(x, y + height));
+    return makePointArray(p);
+}
+
+static PointArray makeComb(Coord x, Coord y, Coord tooth, int teeth, Coord depth) {
+    // More complex rectilinear simple polygon with alternating notches.
+    // Point count is roughly 2 * teeth + 4; with teeth=8 this is 20 points.
+    std::vector<Point> p;
+    const Coord w = tooth * teeth;
+    const Coord h = depth * 3;
+    p.reserve(static_cast<std::size_t>(2 * teeth + 4));
+    p.push_back(Point(x, y));
+    p.push_back(Point(x + w, y));
+    p.push_back(Point(x + w, y + h));
+    for (int i = teeth - 1; i >= 0; --i) {
+        const Coord right = x + tooth * (i + 1);
+        const Coord left = x + tooth * i;
+        if ((i % 2) == 0) {
+            p.push_back(Point(right, y + h - depth));
+            p.push_back(Point(left, y + h - depth));
+        } else {
+            p.push_back(Point(right, y + h));
+            p.push_back(Point(left, y + h));
+        }
+    }
+    p.push_back(Point(x, y));
+    if (!p.empty() && p.front().x == p.back().x && p.front().y == p.back().y) {
+        p.pop_back();
+    }
     return makePointArray(p);
 }
 
@@ -346,8 +376,8 @@ static Dataset makeRectDataset(int count, Coord pitch, Coord size, Coord rhsShif
     d.lhs.reserve(count);
     d.rhs.reserve(count);
     for (int i = 0; i < count; ++i) {
-        Coord x = static_cast<Coord>(i % 200) * pitch;
-        Coord y = static_cast<Coord>(i / 200) * pitch;
+        Coord x = static_cast<Coord>(i % 1000) * pitch;
+        Coord y = static_cast<Coord>(i / 1000) * pitch;
         d.lhs.push_back(makeRect(x, y, x + size, y + size));
         d.rhs.push_back(makeRect(x + rhsShift, y + rhsShift, x + rhsShift + size, y + rhsShift + size));
     }
@@ -355,13 +385,19 @@ static Dataset makeRectDataset(int count, Coord pitch, Coord size, Coord rhsShif
 }
 
 static Dataset makeMixedDataset(int count, Coord pitch, Coord size, Coord rhsShift) {
+    // 70% rectangles, 20% medium stair polygons, 10% more complex comb polygons.
+    // The comb polygons intentionally add ~20-point rectilinear shapes so the
+    // conversion path is not optimized only for rectangles.
     Dataset d;
     d.lhs.reserve(count);
     d.rhs.reserve(count);
     for (int i = 0; i < count; ++i) {
-        Coord x = static_cast<Coord>(i % 200) * pitch;
-        Coord y = static_cast<Coord>(i / 200) * pitch;
-        if ((i % 5) == 0) {
+        Coord x = static_cast<Coord>(i % 1000) * pitch;
+        Coord y = static_cast<Coord>(i / 1000) * pitch;
+        if ((i % 10) == 0) {
+            d.lhs.push_back(makeComb(x, y, size / 4, 8, size / 4));
+            d.rhs.push_back(makeComb(x + rhsShift, y + rhsShift, size / 4, 8, size / 4));
+        } else if ((i % 5) == 0) {
             d.lhs.push_back(makeStair(x, y, size / 4, 4, size));
             d.rhs.push_back(makeStair(x + rhsShift, y + rhsShift, size / 4, 4, size));
         } else {
@@ -477,8 +513,8 @@ static void sanityCheck() {
 
 int main(int argc, char** argv) {
     try {
-        int count = 5000;
-        int rounds = 5;
+        int count = 1000000;
+        int rounds = 1;
         if (argc > 1) {
             count = std::atoi(argv[1]);
         }
@@ -498,7 +534,7 @@ int main(int argc, char** argv) {
         std::cout << "except 'prebuilt sets boolean+extract', which excludes input conversion.\n";
 
         pa90::benchmarkDataset("all rectangles", rects, pa90::BooleanOp::Or, rounds);
-        pa90::benchmarkDataset("80% rectangles + 20% stair polygons", mixed, pa90::BooleanOp::Or, rounds);
+        pa90::benchmarkDataset("70% rectangles + 20% stair + 10% complex comb polygons", mixed, pa90::BooleanOp::Or, rounds);
         pa90::benchmarkDataset("all rectangles", rects, pa90::BooleanOp::And, rounds);
 
         return 0;


### PR DESCRIPTION
## Summary
- Change the PointArray polygon_90 benchmark default to 1,000,000 LHS + 1,000,000 RHS polygons
- Add a more complex rectilinear comb polygon generator and use a mixed dataset: 70% rectangles, 20% stair polygons, 10% complex comb polygons
- Update README with the 1M benchmark results from this machine

## Test Plan
- c++ -O3 -DNDEBUG -std=c++11 boost_polygon90_pointarray_benchmark.cpp -o boost_polygon90_pointarray_benchmark
- ./boost_polygon90_pointarray_benchmark 10000 2
- ./boost_polygon90_pointarray_benchmark 1000000 1
- c++ -O3 -DNDEBUG -std=c++11 boost_polygon90_pointarray_benchmark.cpp -o /tmp/boost_polygon90_pointarray_benchmark_verify && /tmp/boost_polygon90_pointarray_benchmark_verify 10000 1