### PR TITLE
revert: remove polygon90 get vertex threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,6 @@ The benchmark reports separate timing columns for:
 - `get`: `Boost.Polygon set.get(...)` extraction into Boost polygon objects
 - `out_conv`: Boost polygon object -> `PointArray` conversion
 
-For `polygon_90_set_data` only, the benchmark can call Boost's vertex-threshold
-`get(output, vthreshold)` overload.  This fractures 90-degree output polygons so
-large polygons are split around the requested maximum vertex count.  The 45-degree
-and arbitrary-angle set types in Boost.Polygon do not expose the same overload, so
-that argument is ignored for those engines.
-
 ## Copy-friendly engine dispatch snippet
 
 ```cpp
@@ -107,10 +101,6 @@ c++ -O3 -DNDEBUG -std=c++11 pointarray_boost_boolean_benchmark.cpp -o pointarray
 
 # Override count and rounds.
 ./pointarray_boost_boolean_benchmark 1000000 1
-
-# Optional third argument: polygon_90_set_data get vertex threshold.
-# 0 or omitted means unlimited/default get().  Only the 90-degree engine uses it.
-./pointarray_boost_boolean_benchmark 1000000 1 1000
 ```
 
 ## Benchmark datasets
@@ -160,16 +150,6 @@ Timing columns are milliseconds:
 - `boolean`: Boost.Polygon boolean operation only
 - `get`: `set.get(...)` into Boost polygon objects
 - `out_conv`: Boost polygon objects converted back to `PointArray`
-
-Optional 90-degree vertex-threshold example:
-
-```sh
-./pointarray_boost_boolean_benchmark 1000 1 16
-```
-
-This calls `polygon_90_set_data::get(polys, 16)` on the 90-degree result path.
-Because the threshold fractures large polygons, output polygon/point counts can
-change compared with the unlimited/default `get(polys)` path.
 
 Conclusion: keep the dispatch order as `90 -> 45 -> any-angle`.  The 90-degree
 engine is fastest when legal, the 45-degree engine is the right middle path for

--- a/pointarray_boost_boolean_benchmark.cpp
+++ b/pointarray_boost_boolean_benchmark.cpp
@@ -310,30 +310,19 @@ static Set applyBoolean(const Set& lhs, const Set& rhs, BooleanOp op) {
     return out;
 }
 
-template <typename Set, typename OutPoly>
-static std::vector<OutPoly> getBoostPolygons(const Set& set) {
-    std::vector<OutPoly> polys;
+template <typename Set>
+static std::vector<BOutPoly> getBoostPolygons(const Set& set) {
+    std::vector<BOutPoly> polys;
     set.get(polys);
     return polys;
 }
 
-static std::vector<BPoly90> getBoostPolygons90(const BSet90& set, std::size_t vertexThreshold) {
-    std::vector<BPoly90> polys;
-    if (vertexThreshold == 0) {
-        set.get(polys);
-    } else {
-        set.get(polys, vertexThreshold);
-    }
-    return polys;
-}
-
-template <typename BoostPoly>
-static std::vector<PointArray> convertBoostPolygonsToPointArrays(const std::vector<BoostPoly>& polys) {
+static std::vector<PointArray> convertBoostPolygonsToPointArrays(const std::vector<BOutPoly>& polys) {
     std::vector<PointArray> out;
     out.reserve(polys.size());
     for (std::size_t i = 0; i < polys.size(); ++i) {
         std::vector<Point> pts;
-        for (typename bp::polygon_traits<BoostPoly>::iterator_type it = bp::begin_points(polys[i]);
+        for (bp::polygon_traits<BOutPoly>::iterator_type it = bp::begin_points(polys[i]);
              it != bp::end_points(polys[i]); ++it) {
             pts.push_back(Point(bp::get(*it, bp::HORIZONTAL), bp::get(*it, bp::VERTICAL)));
         }
@@ -344,8 +333,7 @@ static std::vector<PointArray> convertBoostPolygonsToPointArrays(const std::vect
 
 static BooleanResult booleanAuto(const std::vector<PointArray>& lhs,
                                 const std::vector<PointArray>& rhs,
-                                BooleanOp op,
-                                std::size_t getVertexThreshold = 0) {
+                                BooleanOp op) {
     BooleanResult result;
 
     double t0 = nowMs();
@@ -360,7 +348,7 @@ static BooleanResult booleanAuto(const std::vector<PointArray>& lhs,
         BSet90 out = applyBoolean(a, b, op);
         double t2 = nowMs();
 
-        std::vector<BPoly90> boostPolys = getBoostPolygons90(out, getVertexThreshold);
+        std::vector<BOutPoly> boostPolys = getBoostPolygons(out);
         double t3 = nowMs();
 
         result.polygons = convertBoostPolygonsToPointArrays(boostPolys);
@@ -379,7 +367,7 @@ static BooleanResult booleanAuto(const std::vector<PointArray>& lhs,
         BSet45 out = applyBoolean(a, b, op);
         double t2 = nowMs();
 
-        std::vector<BOutPoly> boostPolys = getBoostPolygons<BSet45, BOutPoly>(out);
+        std::vector<BOutPoly> boostPolys = getBoostPolygons(out);
         double t3 = nowMs();
 
         result.polygons = convertBoostPolygonsToPointArrays(boostPolys);
@@ -398,7 +386,7 @@ static BooleanResult booleanAuto(const std::vector<PointArray>& lhs,
         BSetAny out = applyBoolean(a, b, op);
         double t2 = nowMs();
 
-        std::vector<BOutPoly> boostPolys = getBoostPolygons<BSetAny, BOutPoly>(out);
+        std::vector<BOutPoly> boostPolys = getBoostPolygons(out);
         double t3 = nowMs();
 
         result.polygons = convertBoostPolygonsToPointArrays(boostPolys);
@@ -464,11 +452,11 @@ static std::size_t countPoints(const std::vector<PointArray>& polys) {
     return n;
 }
 
-static void bench(const std::string& label, const Dataset& d, int rounds, std::size_t getVertexThreshold) {
+static void bench(const std::string& label, const Dataset& d, int rounds) {
     double best = std::numeric_limits<double>::max();
     BooleanResult bestResult;
     for (int r = 0; r < rounds; ++r) {
-        BooleanResult current = booleanAuto(d.lhs, d.rhs, BooleanOp::Or, getVertexThreshold);
+        BooleanResult current = booleanAuto(d.lhs, d.rhs, BooleanOp::Or);
         const double total = current.timing.totalMs();
         if (total < best) {
             best = total;
@@ -502,12 +490,10 @@ int main(int argc, char** argv) {
     try {
         int count = 1000000;
         int rounds = 1;
-        std::size_t getVertexThreshold = 0;
         if (argc > 1) count = std::atoi(argv[1]);
         if (argc > 2) rounds = std::atoi(argv[2]);
-        if (argc > 3) getVertexThreshold = static_cast<std::size_t>(std::strtoull(argv[3], NULL, 10));
         if (count <= 0 || rounds <= 0) {
-            throw std::invalid_argument("usage: ./pointarray_boost_boolean_benchmark [polygon_count] [rounds] [polygon90_get_vertex_threshold]");
+            throw std::invalid_argument("usage: ./pointarray_boost_boolean_benchmark [polygon_count] [rounds]");
         }
 
         pointarray_boolean::sanityCheck();
@@ -518,10 +504,6 @@ int main(int argc, char** argv) {
         std::cout << "PointArray Boost.Polygon auto-dispatch benchmark, op=OR, best-of=" << rounds << "\n";
         std::cout << "Timing columns are milliseconds: total = input conversion + boolean + get + output conversion.\n";
         std::cout << "input conversion includes geometry classification and PointArray->Boost insertion.\n";
-        if (getVertexThreshold != 0) {
-            std::cout << "polygon_90_set_data get vertex threshold=" << getVertexThreshold
-                      << " (only the 90-degree engine supports this Boost overload).\n";
-        }
         std::cout << std::left << std::setw(20) << "dataset"
                   << std::setw(24) << "selected engine"
                   << std::right << std::setw(11) << "total"
@@ -531,9 +513,9 @@ int main(int argc, char** argv) {
                   << std::setw(11) << "out_conv"
                   << std::setw(12) << "out polys"
                   << std::setw(12) << "out points" << '\n';
-        pointarray_boolean::bench("90 rectilinear", d90, rounds, getVertexThreshold);
-        pointarray_boolean::bench("45 mixed", d45, rounds, getVertexThreshold);
-        pointarray_boolean::bench("any angle mixed", any, rounds, getVertexThreshold);
+        pointarray_boolean::bench("90 rectilinear", d90, rounds);
+        pointarray_boolean::bench("45 mixed", d45, rounds);
+        pointarray_boolean::bench("any angle mixed", any, rounds);
         return 0;
     } catch (const std::exception& e) {
         std::cerr << "error: " << e.what() << '\n';


### PR DESCRIPTION
## Summary
- Revert PR #7 / commit 714c48e
- Remove optional polygon90 get vertex threshold CLI argument
- Restore get timing behavior to the split-timing implementation from PR #6

## Test Plan
- c++ -O3 -DNDEBUG -std=c++11 pointarray_boost_boolean_benchmark.cpp -o /tmp/pointarray_boost_boolean_benchmark_revert
- /tmp/pointarray_boost_boolean_benchmark_revert 1000 1