### PR TITLE
refactor: unify CheckDetail properties

### DIFF
--- a/Parser/rdb_check_detail.hpp
+++ b/Parser/rdb_check_detail.hpp
@@ -22,8 +22,8 @@ struct DetailResult {
     ResultKind kind;
     std::uint32_t ordinal;
     std::string signature_suffix;
-    std::vector<DetailTag> properties_before_geometry;
-    std::vector<DetailTag> properties_after_geometry;
+    // 좌표 앞뒤 위치를 구분하지 않고 파일에서 발견한 순서대로 보관한다.
+    std::vector<DetailTag> properties;
     std::vector<Point> vertices;
     std::vector<Edge> edges;
 
@@ -90,7 +90,7 @@ inline void consume_detail_geometry(LineCursor& cursor,
                                     const ResultSignature& signature,
                                     DetailResult& result) {
     // 선언된 좌표 수를 모두 읽을 때까지 진행한다.
-    // 좌표 앞의 태그는 properties_before_geometry에 보관한다.
+    // 좌표 앞의 태그는 properties에 보관한다.
     std::uint64_t seen = 0;
     while (seen < signature.coordinate_count) {
         Line line;
@@ -118,7 +118,7 @@ inline void consume_detail_geometry(LineCursor& cursor,
         if (parse_result_signature(text, unexpected)) {
             throw ScanError(line.offset, "result ended before its declared coordinate count");
         }
-        result.properties_before_geometry.push_back(parse_detail_tag(text));
+        result.properties.push_back(parse_detail_tag(text));
     }
 }
 
@@ -135,7 +135,7 @@ inline void consume_detail_intermediate_tail(LineCursor& cursor, DetailResult& r
             cursor.reset(mark);
             return;
         }
-        result.properties_after_geometry.push_back(parse_detail_tag(trim(line.text)));
+        result.properties.push_back(parse_detail_tag(trim(line.text)));
     }
 }
 
@@ -155,7 +155,7 @@ inline void consume_detail_final_tail(LineCursor& cursor, DetailResult& result) 
 
         Line possible_header;
         if (!next_nonblank(cursor, possible_header)) {
-            result.properties_after_geometry.push_back(parse_detail_tag(trim(candidate.text)));
+            result.properties.push_back(parse_detail_tag(trim(candidate.text)));
             return;
         }
 
@@ -164,7 +164,7 @@ inline void consume_detail_final_tail(LineCursor& cursor, DetailResult& result) 
             return;
         }
 
-        result.properties_after_geometry.push_back(parse_detail_tag(trim(candidate.text)));
+        result.properties.push_back(parse_detail_tag(trim(candidate.text)));
         // possible_header는 이미 읽었지만 다음 후보로 재사용한다.
         // mmap의 Line 포인터는 파싱 중 유효하므로 파일을 다시 읽을 필요가 없다.
         candidate = possible_header;
@@ -219,7 +219,7 @@ inline CheckDetail parse_check_detail(const MappedFile& file, CheckOffset offset
                 found = true;
                 break;
             }
-            result.properties_before_geometry.push_back(
+            result.properties.push_back(
                 parse_detail_tag(trim(signature_line.text)));
         }
         if (!found) throw ScanError(cursor.position(), "truncated result list");
@@ -284,7 +284,7 @@ inline bool consume_detail_geometry_cancellable(
         if (parse_result_signature(text, unexpected)) {
             throw ScanError(line.offset, "result ended before its declared coordinate count");
         }
-        result.properties_before_geometry.push_back(parse_detail_tag(text));
+        result.properties.push_back(parse_detail_tag(text));
     }
     return true;
 }
@@ -305,7 +305,7 @@ inline bool consume_detail_intermediate_tail_cancellable(
             cursor.reset(mark);
             return true;
         }
-        result.properties_after_geometry.push_back(parse_detail_tag(trim(line.text)));
+        result.properties.push_back(parse_detail_tag(trim(line.text)));
     }
 }
 
@@ -327,13 +327,13 @@ inline bool consume_detail_final_tail_cancellable(
 
         Line possible_header;
         if (!next_nonblank(cursor, possible_header)) {
-            result.properties_after_geometry.push_back(parse_detail_tag(trim(candidate.text)));
+            result.properties.push_back(parse_detail_tag(trim(candidate.text)));
             return true;
         }
 
         RuleHeader next_header;
         if (parse_rule_header(trim(possible_header.text), next_header)) return true;
-        result.properties_after_geometry.push_back(parse_detail_tag(trim(candidate.text)));
+        result.properties.push_back(parse_detail_tag(trim(candidate.text)));
         candidate = possible_header;
         have_candidate = true;
     }
@@ -397,7 +397,7 @@ inline CheckDetailBatchResult parse_check_detail_batches(
                 found = true;
                 break;
             }
-            result.properties_before_geometry.push_back(parse_detail_tag(trim(signature_line.text)));
+            result.properties.push_back(parse_detail_tag(trim(signature_line.text)));
         }
         if (!found) throw ScanError(cursor.position(), "truncated result list");
 

--- a/Parser/rdb_parser_tests.cpp
+++ b/Parser/rdb_parser_tests.cpp
@@ -428,7 +428,7 @@ int main() {
     RDB_CHECK(first_check.name == "M1.SPACING.1");
     RDB_CHECK(first_check.results.size() == 2);
     RDB_CHECK(first_check.results[0].vertices.size() == 4);
-    RDB_CHECK(first_check.results[0].properties_before_geometry.size() == 5);
+    RDB_CHECK(first_check.results[0].properties.size() == 5);
     RDB_CHECK(first_check.results[1].edges.size() == 2);
 
     const rdb::CheckDetailFile detail_file(sample_path("standard_sample.rdb"));
@@ -440,8 +440,43 @@ int main() {
     const rdb::CheckDetail extended_check = detail_parser.parse_file_at(
         sample_path("post_coordinate_tags_sample.rdb"),
         index_parser.parse_file(sample_path("post_coordinate_tags_sample.rdb"))[0].offset);
-    RDB_CHECK(extended_check.results[0].properties_after_geometry.size() == 2);
-    RDB_CHECK(extended_check.results[1].properties_after_geometry.size() == 3);
+    RDB_CHECK(extended_check.results[0].properties.size() == 2);
+    RDB_CHECK(extended_check.results[0].properties[0].id == "PP");
+    RDB_CHECK(extended_check.results[0].properties[1].id == "PA");
+    RDB_CHECK(extended_check.results[1].properties.size() == 3);
+    RDB_CHECK(extended_check.results[1].properties[0].id == "EL");
+    RDB_CHECK(extended_check.results[1].properties[2].id == "CN");
+
+    // 좌표 앞뒤에 있던 property는 파일에서 발견한 순서대로 하나의 vector에 보관한다.
+    const TemporaryRdb mixed_property_file(
+        "TOP 1000\nMIXED.PROPERTIES\n1 1 0 Jul 21 10:35:00 2026\n"
+        "PB before geometry\np 1 1\n0 0\nPA after geometry\n");
+    const rdb::CheckOffset mixed_property_offset =
+        index_parser.parse_file(mixed_property_file.path())[0].offset;
+    const rdb::CheckDetail mixed_property_check =
+        detail_parser.parse_file_at(mixed_property_file.path(), mixed_property_offset);
+    RDB_CHECK(mixed_property_check.results[0].properties.size() == 2);
+    RDB_CHECK(mixed_property_check.results[0].properties[0].id == "PB");
+    RDB_CHECK(mixed_property_check.results[0].properties[0].payload == "before geometry");
+    RDB_CHECK(mixed_property_check.results[0].properties[1].id == "PA");
+    RDB_CHECK(mixed_property_check.results[0].properties[1].payload == "after geometry");
+
+    std::size_t mixed_property_batches = 0;
+    rdb::CheckDetailBatchOptions mixed_property_options;
+    mixed_property_options.batch_size = 1U;
+    mixed_property_options.batch_callback = [&mixed_property_batches](
+        const std::vector<rdb::DetailResult>& batch) {
+        ++mixed_property_batches;
+        RDB_CHECK(batch.size() == 1U);
+        RDB_CHECK(batch[0].properties.size() == 2U);
+        RDB_CHECK(batch[0].properties[0].id == "PB");
+        RDB_CHECK(batch[0].properties[1].id == "PA");
+    };
+    const rdb::CheckDetailBatchResult mixed_property_batch_result =
+        detail_parser.parse_file_at_batches(
+            mixed_property_file.path(), mixed_property_offset, mixed_property_options);
+    RDB_CHECK(mixed_property_batch_result.completed);
+    RDB_CHECK(mixed_property_batches == 1U);
 
     // 배치 파서는 정확히 batch_size개마다 결과를 전달하고 마지막 잔여분도 보낸다.
     std::string batched_contents = "TOP 1000\nBATCH.CHECK\n20001 20001 0 Jul 27 12:10:49 2026\n";

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ ASCII Results Database(RDB)를 읽는 C++11 파서다.
 대용량 RDB의 Check 탐색에는 다음 두 파서를 사용한다.
 
 1. `FastCheckIndexParser` — Check 이름, Result 수, comment, 파일 offset 인덱싱
-2. `CheckDetailParser` — index offset에서 선택한 Check만 상세 또는 batch 파싱
+2. `CheckDetailParser` — index offset에서 선택한 Check만 상세 또는 batch 파싱하며,
+   좌표 앞뒤의 property는 `DetailResult::properties`에 발견 순서대로 통합
 
 ## 빌드와 테스트
 


### PR DESCRIPTION
## Summary
- replace `properties_before_geometry` and `properties_after_geometry` in `rdb::DetailResult` with one `properties` vector
- preserve property encounter order across pre-geometry and post-geometry locations
- apply the same representation to regular and batch/cancellable CheckDetail parsing
- document the public API change

## Verification
- TDD RED: compile failed because `DetailResult::properties` did not exist
- Release build and CTest: 2/2 passed
- ASan + UBSan build and CTest: 2/2 passed
- mixed before/after property order tested in regular and batch parsers
- independent pre-commit review: passed