### PR TITLE
feat: add compact indexed RDB database

### DIFF
--- a/Parser/CMakeLists.txt
+++ b/Parser/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(ascii_rdb_parser
     ascii_rdb_parser.cpp
+    rdb_compact_database.cpp
 )
 target_include_directories(ascii_rdb_parser PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_options(ascii_rdb_parser PRIVATE
@@ -20,4 +21,11 @@ if(BUILD_TESTING)
         $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall;-Wextra;-Wpedantic;-Werror>
     )
     add_test(NAME rdb-check-index-header-test COMMAND rdb-check-index-header-test)
+
+    add_executable(rdb-compact-database-header-test rdb_compact_database_header_test.cpp)
+    target_link_libraries(rdb-compact-database-header-test PRIVATE ascii_rdb_parser)
+    target_compile_options(rdb-compact-database-header-test PRIVATE
+        $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall;-Wextra;-Wpedantic;-Werror>
+    )
+    add_test(NAME rdb-compact-database-header-test COMMAND rdb-compact-database-header-test)
 endif()

--- a/Parser/rdb_check_index.hpp
+++ b/Parser/rdb_check_index.hpp
@@ -135,6 +135,16 @@ inline bool same_file_state(const FileState& left, const FileState& right) {
            left.changed_nanoseconds == right.changed_nanoseconds;
 }
 
+// Path replacement can change ctime/link metadata on an otherwise unchanged open
+// inode. Snapshot content identity therefore uses inode, size, and mtime only.
+inline bool same_file_snapshot(const FileState& left, const FileState& right) {
+    return left.device == right.device &&
+           left.inode == right.inode &&
+           left.size == right.size &&
+           left.modified_seconds == right.modified_seconds &&
+           left.modified_nanoseconds == right.modified_nanoseconds;
+}
+
 // 파일 버퍼를 복사하지 않고 [begin, end) 포인터 두 개로 표현한 문자열 조각이다.
 // 대형 파일에서 std::string을 매 줄마다 만들지 않기 위해 사용한다.
 struct Span {
@@ -270,6 +280,10 @@ public:
 
     const char* data() const { return data_ != 0 ? data_ : ""; }
     std::size_t size() const { return size_; }
+    // The descriptor remains owned by this object. Callers must not close it;
+    // consumers that outlive a call must duplicate it first.
+    int descriptor() const { return fd_; }
+    FileState state() const { return capture_file_state(fd_); }
 
 private:
     MappedFile(const MappedFile&);
@@ -580,6 +594,7 @@ public:
           last_progress_(-1),
           context_bytes_(options.context_bytes),
           buffer_offset_(0),
+          read_offset_(0),
           buffer_starts_at_line_boundary_(true) {
         if (options.read_buffer_bytes == 0 || options.context_bytes < 64U) {
             throw std::invalid_argument("fast RDB index buffer/context size is too small");
@@ -602,6 +617,46 @@ public:
         }
 #ifdef POSIX_FADV_SEQUENTIAL
         // 인덱스는 첫 바이트부터 한 번만 읽으므로 커널 readahead에 순차 접근을 알려 준다.
+        (void)::posix_fadvise(fd_, 0, 0, POSIX_FADV_SEQUENTIAL);
+#endif
+    }
+
+    HeaderPatternIndexReader(int source_fd, const FastCheckIndexOptions& options)
+        : fd_(-1),
+          initial_state_(),
+          progress_callback_(options.progress_callback),
+          cancellation_callback_(options.is_cancelled),
+          last_progress_(-1),
+          context_bytes_(options.context_bytes),
+          buffer_offset_(0),
+          read_offset_(0),
+          buffer_starts_at_line_boundary_(true) {
+        if (source_fd < 0) throw std::invalid_argument("invalid RDB file descriptor");
+        if (options.read_buffer_bytes == 0 || options.context_bytes < 64U) {
+            throw std::invalid_argument("fast RDB index buffer/context size is too small");
+        }
+        if (options.read_buffer_bytes > std::numeric_limits<std::size_t>::max() - options.context_bytes) {
+            throw std::length_error("fast RDB index buffer size overflows size_t");
+        }
+        buffer_.resize(options.read_buffer_bytes + options.context_bytes);
+#ifdef F_DUPFD_CLOEXEC
+        fd_ = ::fcntl(source_fd, F_DUPFD_CLOEXEC, 0);
+#else
+        fd_ = ::dup(source_fd);
+        if (fd_ >= 0) (void)::fcntl(fd_, F_SETFD, FD_CLOEXEC);
+#endif
+        if (fd_ < 0) {
+            throw std::runtime_error(
+                "cannot duplicate RDB file descriptor: " + std::string(std::strerror(errno)));
+        }
+        try {
+            initial_state_ = capture_file_state(fd_);
+        } catch (...) {
+            ::close(fd_);
+            fd_ = -1;
+            throw;
+        }
+#ifdef POSIX_FADV_SEQUENTIAL
         (void)::posix_fadvise(fd_, 0, 0, POSIX_FADV_SEQUENTIAL);
 #endif
     }
@@ -862,9 +917,16 @@ private:
     }
 
     ssize_t read_block(char* destination, std::size_t capacity) {
+        if (read_offset_ > static_cast<CheckOffset>(std::numeric_limits<off_t>::max())) {
+            throw ScanError(read_offset_, "RDB read offset exceeds platform file range");
+        }
         for (;;) {
-            const ssize_t received = ::read(fd_, destination, capacity);
-            if (received >= 0) return received;
+            const ssize_t received =
+                ::pread(fd_, destination, capacity, static_cast<off_t>(read_offset_));
+            if (received >= 0) {
+                read_offset_ += static_cast<CheckOffset>(received);
+                return received;
+            }
             if (errno != EINTR) {
                 throw std::runtime_error("cannot read RDB file: " + std::string(std::strerror(errno)));
             }
@@ -911,6 +973,7 @@ private:
     std::vector<char> buffer_;
     std::size_t context_bytes_;
     CheckOffset buffer_offset_;
+    CheckOffset read_offset_;
     bool buffer_starts_at_line_boundary_;
 };
 
@@ -949,11 +1012,25 @@ public:
         return detail::HeaderPatternIndexReader(path, options).run();
     }
 
+    // Duplicates fd and scans that exact open file, independent of path replacement.
+    // pread is used so the caller's descriptor offset is not changed.
+    CheckIndexDatabase parse_database(
+        int fd,
+        const FastCheckIndexOptions& options = FastCheckIndexOptions()) const {
+        return detail::HeaderPatternIndexReader(fd, options).run();
+    }
+
     // 기존 Check 목록 전용 API를 유지한다.
     std::vector<CheckIndexEntry> parse_file(
         const std::string& path,
         const FastCheckIndexOptions& options = FastCheckIndexOptions()) const {
         return parse_database(path, options).checks;
+    }
+
+    std::vector<CheckIndexEntry> parse_file(
+        int fd,
+        const FastCheckIndexOptions& options = FastCheckIndexOptions()) const {
+        return parse_database(fd, options).checks;
     }
 };
 

--- a/Parser/rdb_check_index_header_test.cpp
+++ b/Parser/rdb_check_index_header_test.cpp
@@ -1,5 +1,13 @@
 #include "rdb_check_index.hpp"
 
+#include <type_traits>
+#include <utility>
+
+static_assert(std::is_same<
+                  decltype(std::declval<const rdb::FastCheckIndexParser&>().parse_database(-1)),
+                  rdb::CheckIndexDatabase>::value,
+              "fast index parser must retain its descriptor overload");
+
 int main() {
     const rdb::FastCheckIndexParser parser;
     rdb::FastCheckIndexOptions options;

--- a/Parser/rdb_compact_database.cpp
+++ b/Parser/rdb_compact_database.cpp
@@ -1,0 +1,444 @@
+#include "rdb_compact_database.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <stdexcept>
+
+namespace rdb {
+namespace {
+
+const std::size_t compact_max =
+    static_cast<std::size_t>(std::numeric_limits<CompactIndex>::max());
+
+void require_array_capacity(std::size_t current, std::size_t added, const char* what) {
+    if (added > compact_max || current > compact_max - added) {
+        throw std::length_error(std::string(what) + " exceeds 32-bit capacity");
+    }
+}
+
+void require_text_capacity(std::size_t current, const std::string& value) {
+    require_array_capacity(current, value.size(), "compact RDB text pool");
+}
+
+void add_text_requirement(std::size_t base,
+                          std::size_t& additional,
+                          const std::string& value) {
+    require_array_capacity(base, additional, "compact RDB text pool");
+    const std::size_t current = base + additional;
+    require_array_capacity(current, value.size(), "compact RDB text pool");
+    additional += value.size();
+}
+
+template <typename T>
+void add_memory(CompactMemoryUsage& usage, const std::vector<T>& values) {
+    const std::size_t maximum = std::numeric_limits<std::size_t>::max();
+    const std::size_t used = values.size() > maximum / sizeof(T)
+        ? maximum : values.size() * sizeof(T);
+    const std::size_t capacity = values.capacity() > maximum / sizeof(T)
+        ? maximum : values.capacity() * sizeof(T);
+    usage.used_bytes = usage.used_bytes > maximum - used ? maximum : usage.used_bytes + used;
+    usage.capacity_bytes = usage.capacity_bytes > maximum - capacity
+        ? maximum : usage.capacity_bytes + capacity;
+}
+
+bool valid_kind(ResultKind kind) {
+    return kind == ResultKind::Polygon || kind == ResultKind::EdgeCluster;
+}
+
+} // namespace
+
+CompactCheckDatabase::CompactCheckDatabase()
+    : database_precision_(0.0), loaded_check_count_(0) {}
+
+TextRef CompactCheckDatabase::append_text(const std::string& value) {
+    require_text_capacity(text_pool_.size(), value);
+    const CompactIndex offset = static_cast<CompactIndex>(text_pool_.size());
+    if (!value.empty()) text_pool_.insert(text_pool_.end(), value.begin(), value.end());
+    return TextRef(offset, static_cast<CompactIndex>(value.size()));
+}
+
+TextView CompactCheckDatabase::text(const TextRef& ref) const {
+    const std::size_t offset = ref.offset;
+    const std::size_t size = ref.size;
+    if (offset > text_pool_.size() || size > text_pool_.size() - offset) {
+        throw std::logic_error("corrupt compact RDB text reference");
+    }
+    return TextView(size == 0 ? 0 : &text_pool_[offset], ref.size);
+}
+
+CompactCheckDatabase CompactCheckDatabase::from_index(const CheckIndexDatabase& index) {
+    if (!std::isfinite(index.database_precision) || index.database_precision <= 0.0) {
+        throw std::invalid_argument("compact RDB database precision must be a finite positive value");
+    }
+    if (index.top_cell_name.empty()) {
+        throw std::invalid_argument("compact RDB top-cell name must not be empty");
+    }
+    if (index.checks.size() >= compact_max) {
+        throw std::length_error("compact RDB check list exceeds 32-bit ID capacity");
+    }
+
+    std::size_t bytes = index.top_cell_name.size();
+    if (bytes > compact_max) throw std::length_error("compact RDB text pool exceeds 32-bit capacity");
+    for (std::size_t i = 0; i < index.checks.size(); ++i) {
+        const CheckIndexEntry& entry = index.checks[i];
+        if (entry.name.empty()) throw std::invalid_argument("compact RDB check name must not be empty");
+        require_text_capacity(bytes, entry.name);
+        bytes += entry.name.size();
+        require_text_capacity(bytes, entry.comment);
+        bytes += entry.comment.size();
+    }
+
+    CompactCheckDatabase database;
+    database.database_precision_ = index.database_precision;
+    database.text_pool_.reserve(bytes);
+    database.checks_.reserve(index.checks.size());
+    database.top_cell_name_ = database.append_text(index.top_cell_name);
+    for (std::size_t i = 0; i < index.checks.size(); ++i) {
+        const CheckIndexEntry& entry = index.checks[i];
+        CompactCheckRecord record;
+        record.offset = entry.offset;
+        record.name = database.append_text(entry.name);
+        record.comment = database.append_text(entry.comment);
+        record.result_count = entry.geometry_count;
+        database.checks_.push_back(record);
+    }
+    return database;
+}
+
+TextView CompactCheckDatabase::top_cell_name() const { return text(top_cell_name_); }
+
+const CompactCheckRecord& CompactCheckDatabase::check_record(CheckId id) const {
+    if (id == invalid_check_id() || static_cast<std::size_t>(id) >= checks_.size()) {
+        throw std::out_of_range("compact RDB check ID is out of range");
+    }
+    return checks_[id];
+}
+
+CompactCheckRecord& CompactCheckDatabase::check_record(CheckId id) {
+    if (id == invalid_check_id() || static_cast<std::size_t>(id) >= checks_.size()) {
+        throw std::out_of_range("compact RDB check ID is out of range");
+    }
+    return checks_[id];
+}
+
+const CompactDetailRecord& CompactCheckDatabase::detail_record(CheckId id) const {
+    const CompactCheckRecord& record = check_record(id);
+    if (record.detail == std::numeric_limits<CompactIndex>::max()) {
+        throw std::logic_error("compact RDB check detail has not been loaded");
+    }
+    if (static_cast<std::size_t>(record.detail) >= details_.size()) {
+        throw std::logic_error("corrupt compact RDB detail reference");
+    }
+    return details_[record.detail];
+}
+
+CompactCheckView CompactCheckDatabase::check(CheckId id) const {
+    (void)check_record(id);
+    return CompactCheckView(this, id);
+}
+
+CheckId CompactCheckDatabase::find_check_by_offset(CheckOffset offset) const {
+    for (std::size_t i = 0; i < checks_.size(); ++i) {
+        if (checks_[i].offset == offset) return static_cast<CheckId>(i);
+    }
+    return invalid_check_id();
+}
+
+std::vector<CheckId> CompactCheckDatabase::find_checks(const std::string& name) const {
+    std::vector<CheckId> found;
+    for (std::size_t i = 0; i < checks_.size(); ++i) {
+        const TextView value = text(checks_[i].name);
+        if (value.size == name.size() &&
+            (value.size == 0 || std::memcmp(value.data, name.data(), value.size) == 0)) {
+            found.push_back(static_cast<CheckId>(i));
+        }
+    }
+    return found;
+}
+
+CompactIndex CompactCheckDatabase::intern_tag_name(const std::string& name) {
+    for (std::size_t i = 0; i < tag_names_.size(); ++i) {
+        const TextView value = text(tag_names_[i]);
+        if (value.size == name.size() &&
+            (value.size == 0 || std::memcmp(value.data, name.data(), value.size) == 0)) {
+            return static_cast<CompactIndex>(i);
+        }
+    }
+    require_array_capacity(tag_names_.size(), 1U, "compact RDB tag-name table");
+    const TextRef ref = append_text(name);
+    tag_names_.push_back(ref);
+    return static_cast<CompactIndex>(tag_names_.size() - 1U);
+}
+
+void CompactCheckDatabase::store_detail(CheckId id, const CheckDetail& detail) {
+    CompactCheckRecord& check = check_record(id);
+    if (check.detail != std::numeric_limits<CompactIndex>::max()) {
+        throw std::logic_error("compact RDB check detail is already loaded");
+    }
+    const TextView indexed_name = text(check.name);
+    if (detail.name.size() != indexed_name.size ||
+        (indexed_name.size != 0 &&
+         std::memcmp(detail.name.data(), indexed_name.data, indexed_name.size) != 0)) {
+        throw std::invalid_argument("detail check name does not match compact index");
+    }
+    if (detail.offset != check.offset) {
+        throw std::invalid_argument("detail check offset does not match compact index");
+    }
+    if (detail.current_result_count != check.result_count ||
+        detail.results.size() != detail.current_result_count) {
+        throw std::invalid_argument("detail result count does not match compact index/header");
+    }
+    if (detail.current_result_count > detail.original_result_count) {
+        throw std::invalid_argument("detail current result count exceeds original result count");
+    }
+
+    require_array_capacity(details_.size(), 1U, "compact RDB detail list");
+    require_array_capacity(results_.size(), detail.results.size(), "compact RDB result list");
+    require_array_capacity(check_text_.size(), detail.check_text.size(), "compact RDB check-text list");
+    std::size_t additional_text = 0;
+    add_text_requirement(text_pool_.size(), additional_text, detail.executed_at);
+    for (std::size_t i = 0; i < detail.check_text.size(); ++i) {
+        add_text_requirement(text_pool_.size(), additional_text, detail.check_text[i]);
+    }
+
+    std::size_t property_add = 0;
+    std::size_t point_add = 0;
+    std::size_t edge_add = 0;
+    std::vector<const std::string*> new_tag_names;
+    for (std::size_t i = 0; i < detail.results.size(); ++i) {
+        const DetailResult& result = detail.results[i];
+        if (!valid_kind(result.kind)) throw std::invalid_argument("detail contains an invalid result kind");
+        if ((result.kind == ResultKind::Polygon && !result.edges.empty()) ||
+            (result.kind == ResultKind::EdgeCluster && !result.vertices.empty())) {
+            throw std::invalid_argument("detail result geometry does not match its kind");
+        }
+        require_array_capacity(property_add, result.properties.size(), "detail property count");
+        property_add += result.properties.size();
+        require_array_capacity(point_add, result.vertices.size(), "detail point count");
+        point_add += result.vertices.size();
+        require_array_capacity(edge_add, result.edges.size(), "detail edge count");
+        edge_add += result.edges.size();
+        add_text_requirement(text_pool_.size(), additional_text, result.signature_suffix);
+        for (std::size_t j = 0; j < result.properties.size(); ++j) {
+            const DetailTag& property = result.properties[j];
+            if (property.id.empty()) throw std::invalid_argument("detail property tag ID must not be empty");
+            add_text_requirement(text_pool_.size(), additional_text, property.payload);
+            bool known = false;
+            for (std::size_t k = 0; k < tag_names_.size() && !known; ++k) {
+                const TextView tag = text(tag_names_[k]);
+                known = tag.size == property.id.size() &&
+                    (tag.size == 0 || std::memcmp(tag.data, property.id.data(), tag.size) == 0);
+            }
+            for (std::size_t k = 0; k < new_tag_names.size() && !known; ++k) {
+                known = *new_tag_names[k] == property.id;
+            }
+            if (!known) {
+                add_text_requirement(text_pool_.size(), additional_text, property.id);
+                new_tag_names.push_back(&property.id);
+            }
+        }
+    }
+    require_array_capacity(properties_.size(), property_add, "compact RDB property list");
+    require_array_capacity(points_.size(), point_add, "compact RDB point list");
+    require_array_capacity(edges_.size(), edge_add, "compact RDB edge list");
+    require_array_capacity(tag_names_.size(), new_tag_names.size(), "compact RDB tag-name table");
+    require_array_capacity(text_pool_.size(), additional_text, "compact RDB text pool");
+
+    // Allocate every known final capacity first. A reserve failure leaves all logical sizes intact.
+    text_pool_.reserve(text_pool_.size() + additional_text);
+    details_.reserve(details_.size() + 1U);
+    results_.reserve(results_.size() + detail.results.size());
+    properties_.reserve(properties_.size() + property_add);
+    points_.reserve(points_.size() + point_add);
+    edges_.reserve(edges_.size() + edge_add);
+    check_text_.reserve(check_text_.size() + detail.check_text.size());
+    tag_names_.reserve(tag_names_.size() + new_tag_names.size());
+
+    const std::size_t text_size = text_pool_.size();
+    const std::size_t detail_size = details_.size();
+    const std::size_t result_size = results_.size();
+    const std::size_t property_size = properties_.size();
+    const std::size_t point_size = points_.size();
+    const std::size_t edge_size = edges_.size();
+    const std::size_t check_text_size = check_text_.size();
+    const std::size_t tag_name_size = tag_names_.size();
+
+    try {
+        CompactDetailRecord stored_detail;
+        stored_detail.executed_at = append_text(detail.executed_at);
+        stored_detail.current_result_count = detail.current_result_count;
+        stored_detail.original_result_count = detail.original_result_count;
+        stored_detail.check_text = CompactRange(
+            static_cast<CompactIndex>(check_text_.size()),
+            static_cast<CompactIndex>(detail.check_text.size()));
+        for (std::size_t i = 0; i < detail.check_text.size(); ++i) {
+            check_text_.push_back(append_text(detail.check_text[i]));
+        }
+        stored_detail.results = CompactRange(
+            static_cast<CompactIndex>(results_.size()),
+            static_cast<CompactIndex>(detail.results.size()));
+
+        for (std::size_t i = 0; i < detail.results.size(); ++i) {
+            const DetailResult& source = detail.results[i];
+            CompactResultRecord result;
+            result.kind = source.kind;
+            result.ordinal = source.ordinal;
+            result.signature_suffix = append_text(source.signature_suffix);
+            result.properties = CompactRange(
+                static_cast<CompactIndex>(properties_.size()),
+                static_cast<CompactIndex>(source.properties.size()));
+            for (std::size_t j = 0; j < source.properties.size(); ++j) {
+                const DetailTag& property = source.properties[j];
+                const CompactIndex tag = intern_tag_name(property.id);
+                properties_.push_back(CompactPropertyRecord(tag, append_text(property.payload)));
+            }
+            if (source.kind == ResultKind::Polygon) {
+                result.geometry = CompactRange(static_cast<CompactIndex>(points_.size()),
+                                               static_cast<CompactIndex>(source.vertices.size()));
+                points_.insert(points_.end(), source.vertices.begin(), source.vertices.end());
+            } else {
+                result.geometry = CompactRange(static_cast<CompactIndex>(edges_.size()),
+                                               static_cast<CompactIndex>(source.edges.size()));
+                edges_.insert(edges_.end(), source.edges.begin(), source.edges.end());
+            }
+            results_.push_back(result);
+        }
+        details_.push_back(stored_detail);
+        check.detail = static_cast<CompactIndex>(details_.size() - 1U);
+        ++loaded_check_count_;
+    } catch (...) {
+        text_pool_.resize(text_size);
+        details_.resize(detail_size);
+        results_.resize(result_size);
+        properties_.resize(property_size);
+        points_.resize(point_size);
+        edges_.resize(edge_size);
+        check_text_.resize(check_text_size);
+        tag_names_.resize(tag_name_size);
+        throw;
+    }
+}
+
+CompactMemoryUsage CompactCheckDatabase::memory_usage() const {
+    CompactMemoryUsage usage;
+    add_memory(usage, text_pool_);
+    add_memory(usage, checks_);
+    add_memory(usage, details_);
+    add_memory(usage, results_);
+    add_memory(usage, properties_);
+    add_memory(usage, points_);
+    add_memory(usage, edges_);
+    add_memory(usage, check_text_);
+    add_memory(usage, tag_names_);
+    return usage;
+}
+
+TextView CompactPropertyView::id() const {
+    if (static_cast<std::size_t>(index_) >= database_->properties_.size())
+        throw std::out_of_range("compact RDB property index is out of range");
+    const CompactPropertyRecord& property = database_->properties_[index_];
+    if (static_cast<std::size_t>(property.tag_name) >= database_->tag_names_.size())
+        throw std::logic_error("corrupt compact RDB tag-name reference");
+    return database_->text(database_->tag_names_[property.tag_name]);
+}
+
+TextView CompactPropertyView::payload() const {
+    if (static_cast<std::size_t>(index_) >= database_->properties_.size())
+        throw std::out_of_range("compact RDB property index is out of range");
+    return database_->text(database_->properties_[index_].payload);
+}
+
+ResultKind CompactResultView::kind() const { return database_->results_.at(index_).kind; }
+std::uint32_t CompactResultView::ordinal() const { return database_->results_.at(index_).ordinal; }
+TextView CompactResultView::signature_suffix() const {
+    return database_->text(database_->results_.at(index_).signature_suffix);
+}
+std::size_t CompactResultView::property_count() const { return database_->results_.at(index_).properties.count; }
+CompactPropertyView CompactResultView::property(std::size_t index) const {
+    const CompactResultRecord& result = database_->results_.at(index_);
+    if (index >= result.properties.count) throw std::out_of_range("compact RDB property index is out of range");
+    return CompactPropertyView(database_, result.properties.begin + static_cast<CompactIndex>(index));
+}
+std::size_t CompactResultView::vertex_count() const {
+    const CompactResultRecord& result = database_->results_.at(index_);
+    return result.kind == ResultKind::Polygon ? result.geometry.count : 0U;
+}
+Point CompactResultView::vertex(std::size_t index) const {
+    const CompactResultRecord& result = database_->results_.at(index_);
+    if (result.kind != ResultKind::Polygon || index >= result.geometry.count)
+        throw std::out_of_range("compact RDB vertex index is out of range");
+    return database_->points_.at(result.geometry.begin + static_cast<CompactIndex>(index));
+}
+std::size_t CompactResultView::edge_count() const {
+    const CompactResultRecord& result = database_->results_.at(index_);
+    return result.kind == ResultKind::EdgeCluster ? result.geometry.count : 0U;
+}
+Edge CompactResultView::edge(std::size_t index) const {
+    const CompactResultRecord& result = database_->results_.at(index_);
+    if (result.kind != ResultKind::EdgeCluster || index >= result.geometry.count)
+        throw std::out_of_range("compact RDB edge index is out of range");
+    return database_->edges_.at(result.geometry.begin + static_cast<CompactIndex>(index));
+}
+
+TextView CompactCheckView::name() const { return database_->text(database_->check_record(id_).name); }
+TextView CompactCheckView::comment() const { return database_->text(database_->check_record(id_).comment); }
+CheckOffset CompactCheckView::offset() const { return database_->check_record(id_).offset; }
+std::uint32_t CompactCheckView::result_count() const { return database_->check_record(id_).result_count; }
+bool CompactCheckView::detail_loaded() const {
+    return database_->check_record(id_).detail != std::numeric_limits<CompactIndex>::max();
+}
+TextView CompactCheckView::executed_at() const { return database_->text(database_->detail_record(id_).executed_at); }
+std::uint32_t CompactCheckView::current_result_count() const {
+    return database_->detail_record(id_).current_result_count;
+}
+std::uint32_t CompactCheckView::original_result_count() const {
+    return database_->detail_record(id_).original_result_count;
+}
+std::size_t CompactCheckView::check_text_count() const { return database_->detail_record(id_).check_text.count; }
+TextView CompactCheckView::check_text(std::size_t index) const {
+    const CompactDetailRecord& detail = database_->detail_record(id_);
+    if (index >= detail.check_text.count) throw std::out_of_range("compact RDB check-text index is out of range");
+    return database_->text(database_->check_text_.at(
+        detail.check_text.begin + static_cast<CompactIndex>(index)));
+}
+std::size_t CompactCheckView::detail_result_count() const { return database_->detail_record(id_).results.count; }
+CompactResultView CompactCheckView::result(std::size_t index) const {
+    const CompactDetailRecord& detail = database_->detail_record(id_);
+    if (index >= detail.results.count) throw std::out_of_range("compact RDB result index is out of range");
+    return CompactResultView(database_, detail.results.begin + static_cast<CompactIndex>(index));
+}
+
+IndexedRdbFile::IndexedRdbFile(const std::string& path, const FastCheckIndexOptions& options)
+    : file_(path),
+      file_state_(file_.state()),
+      database_(CompactCheckDatabase::from_index(
+          FastCheckIndexParser().parse_database(file_.descriptor(), options))) {
+    verify_file_unchanged();
+}
+
+void IndexedRdbFile::verify_file_unchanged() const {
+    if (!detail::same_file_snapshot(file_state_, file_.state())) {
+        throw ScanError(0, "RDB file changed after indexed snapshot was opened");
+    }
+}
+
+CompactCheckView IndexedRdbFile::load_check(CheckId id) {
+    verify_file_unchanged();
+    CompactCheckView selected = database_.check(id);
+    if (!selected.detail_loaded()) {
+        const CheckDetail detail = detail::parse_check_detail(file_, selected.offset());
+        verify_file_unchanged();
+        database_.store_detail(id, detail);
+    }
+    verify_file_unchanged();
+    return database_.check(id);
+}
+
+void IndexedRdbFile::load_all() {
+    for (std::size_t i = 0; i < database_.check_count(); ++i) {
+        (void)load_check(static_cast<CheckId>(i));
+    }
+}
+
+} // namespace rdb

--- a/Parser/rdb_compact_database.hpp
+++ b/Parser/rdb_compact_database.hpp
@@ -1,0 +1,224 @@
+#ifndef RDB_COMPACT_DATABASE_HPP
+#define RDB_COMPACT_DATABASE_HPP
+
+#include "rdb_check_detail.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace rdb {
+
+// All compact IDs and ranges are 32 bit. CheckOffset deliberately remains 64 bit.
+typedef std::uint32_t CheckId;
+typedef std::uint32_t CompactIndex;
+
+inline CheckId invalid_check_id() { return std::numeric_limits<CheckId>::max(); }
+
+struct CompactRange {
+    CompactIndex begin;
+    CompactIndex count;
+    CompactRange() : begin(0), count(0) {}
+    CompactRange(CompactIndex first, CompactIndex size) : begin(first), count(size) {}
+};
+
+struct TextRef {
+    CompactIndex offset;
+    CompactIndex size;
+    TextRef() : offset(0), size(0) {}
+    TextRef(CompactIndex first, CompactIndex length) : offset(first), size(length) {}
+};
+
+// A borrowed view into the database byte pool. Loading more details can reallocate
+// that pool and invalidate previously returned TextViews; obtain the view again then.
+struct TextView {
+    const char* data;
+    CompactIndex size;
+    TextView() : data(0), size(0) {}
+    TextView(const char* value, CompactIndex length) : data(value), size(length) {}
+    bool empty() const { return size == 0; }
+    std::string str() const { return data == 0 ? std::string() : std::string(data, size); }
+};
+
+struct CompactCheckRecord {
+    CheckOffset offset;
+    TextRef name;
+    TextRef comment;
+    std::uint32_t result_count;
+    CompactIndex detail;
+    CompactCheckRecord()
+        : offset(0), result_count(0), detail(std::numeric_limits<CompactIndex>::max()) {}
+};
+
+struct CompactDetailRecord {
+    TextRef executed_at;
+    std::uint32_t current_result_count;
+    std::uint32_t original_result_count;
+    CompactRange check_text;
+    CompactRange results;
+    CompactDetailRecord() : current_result_count(0), original_result_count(0) {}
+};
+
+struct CompactResultRecord {
+    CompactRange properties;
+    CompactRange geometry;
+    TextRef signature_suffix;
+    std::uint32_t ordinal;
+    ResultKind kind;
+    CompactResultRecord() : ordinal(0), kind(ResultKind::Polygon) {}
+};
+
+struct CompactPropertyRecord {
+    CompactIndex tag_name;
+    TextRef payload;
+    CompactPropertyRecord() : tag_name(0) {}
+    CompactPropertyRecord(CompactIndex id, const TextRef& value) : tag_name(id), payload(value) {}
+};
+
+static_assert(sizeof(CompactCheckRecord) <= 32U,
+              "CompactCheckRecord must remain at most 32 bytes");
+static_assert(sizeof(CompactResultRecord) <= 32U,
+              "CompactResultRecord must remain at most 32 bytes");
+static_assert(sizeof(CompactPropertyRecord) <= 12U,
+              "CompactPropertyRecord must remain at most 12 bytes");
+
+struct CompactMemoryUsage {
+    std::size_t used_bytes;
+    std::size_t capacity_bytes;
+    CompactMemoryUsage() : used_bytes(0), capacity_bytes(0) {}
+};
+
+class CompactCheckDatabase;
+
+class CompactPropertyView {
+public:
+    TextView id() const;
+    TextView payload() const;
+private:
+    friend class CompactResultView;
+    CompactPropertyView(const CompactCheckDatabase* database, CompactIndex index)
+        : database_(database), index_(index) {}
+    const CompactCheckDatabase* database_;
+    CompactIndex index_;
+};
+
+class CompactResultView {
+public:
+    ResultKind kind() const;
+    std::uint32_t ordinal() const;
+    TextView signature_suffix() const;
+    std::size_t property_count() const;
+    CompactPropertyView property(std::size_t index) const;
+    std::size_t vertex_count() const;
+    // Geometry is returned by value and remains valid after later detail loads.
+    Point vertex(std::size_t index) const;
+    std::size_t edge_count() const;
+    Edge edge(std::size_t index) const;
+private:
+    friend class CompactCheckView;
+    CompactResultView(const CompactCheckDatabase* database, CompactIndex index)
+        : database_(database), index_(index) {}
+    const CompactCheckDatabase* database_;
+    CompactIndex index_;
+};
+
+class CompactCheckView {
+public:
+    CheckId id() const { return id_; }
+    TextView name() const;
+    TextView comment() const;
+    CheckOffset offset() const;
+    std::uint32_t result_count() const;
+    bool detail_loaded() const;
+    TextView executed_at() const;
+    std::uint32_t current_result_count() const;
+    std::uint32_t original_result_count() const;
+    std::size_t check_text_count() const;
+    TextView check_text(std::size_t index) const;
+    std::size_t detail_result_count() const;
+    CompactResultView result(std::size_t index) const;
+private:
+    friend class CompactCheckDatabase;
+    CompactCheckView(const CompactCheckDatabase* database, CheckId id)
+        : database_(database), id_(id) {}
+    const CompactCheckDatabase* database_;
+    CheckId id_;
+};
+
+class CompactCheckDatabase {
+public:
+    CompactCheckDatabase();
+    static CompactCheckDatabase from_index(const CheckIndexDatabase& index);
+
+    TextView top_cell_name() const;
+    double database_precision() const { return database_precision_; }
+    std::size_t check_count() const { return checks_.size(); }
+    std::size_t loaded_check_count() const { return loaded_check_count_; }
+    CompactCheckView check(CheckId id) const;
+    CheckId find_check_by_offset(CheckOffset offset) const;
+    // Name and offset lookup are intentionally linear to avoid auxiliary maps.
+    // Complexity is O(check_count); tag interning is linear in distinct tag names.
+    std::vector<CheckId> find_checks(const std::string& name) const;
+    void store_detail(CheckId id, const CheckDetail& detail);
+    // Counts owned compact byte-pool/vector storage only. It excludes this object,
+    // allocator bookkeeping, temporary parser values, and any mapped RDB file.
+    CompactMemoryUsage memory_usage() const;
+
+private:
+    friend class CompactPropertyView;
+    friend class CompactResultView;
+    friend class CompactCheckView;
+
+    TextView text(const TextRef& ref) const;
+    CompactCheckRecord& check_record(CheckId id);
+    const CompactCheckRecord& check_record(CheckId id) const;
+    const CompactDetailRecord& detail_record(CheckId id) const;
+    CompactIndex intern_tag_name(const std::string& name);
+    TextRef append_text(const std::string& value);
+
+    std::vector<char> text_pool_;
+    TextRef top_cell_name_;
+    double database_precision_;
+    std::vector<CompactCheckRecord> checks_;
+    std::vector<CompactDetailRecord> details_;
+    std::vector<CompactResultRecord> results_;
+    std::vector<CompactPropertyRecord> properties_;
+    std::vector<Point> points_;
+    std::vector<Edge> edges_;
+    std::vector<TextRef> check_text_;
+    std::vector<TextRef> tag_names_;
+    std::size_t loaded_check_count_;
+};
+
+// Owns one mmap and indexes/parses details from that same open-file snapshot.
+// Replacing the source path does not switch this object to the replacement file.
+class IndexedRdbFile {
+public:
+    explicit IndexedRdbFile(
+        const std::string& path,
+        const FastCheckIndexOptions& options = FastCheckIndexOptions());
+
+    CompactCheckDatabase& database() { return database_; }
+    const CompactCheckDatabase& database() const { return database_; }
+    std::size_t check_count() const { return database_.check_count(); }
+    CompactCheckView check(CheckId id) const { return database_.check(id); }
+    std::vector<CheckId> find_checks(const std::string& name) const {
+        return database_.find_checks(name);
+    }
+    CompactCheckView load_check(CheckId id);
+    void load_all();
+
+private:
+    IndexedRdbFile(const IndexedRdbFile&);
+    IndexedRdbFile& operator=(const IndexedRdbFile&);
+    void verify_file_unchanged() const;
+    detail::MappedFile file_;
+    detail::FileState file_state_;
+    CompactCheckDatabase database_;
+};
+
+} // namespace rdb
+
+#endif // RDB_COMPACT_DATABASE_HPP

--- a/Parser/rdb_compact_database_header_test.cpp
+++ b/Parser/rdb_compact_database_header_test.cpp
@@ -1,0 +1,24 @@
+#include "rdb_compact_database.hpp"
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+static_assert(sizeof(rdb::CheckId) == 4U, "compact check IDs must be 32 bit");
+static_assert(std::is_same<
+                  decltype(std::declval<const rdb::CompactResultView&>().vertex(0U)),
+                  rdb::Point>::value,
+              "compact vertices must be returned by value");
+static_assert(std::is_same<
+                  decltype(std::declval<const rdb::CompactResultView&>().edge(0U)),
+                  rdb::Edge>::value,
+              "compact edges must be returned by value");
+static_assert(sizeof(rdb::CheckOffset) == 8U, "file offsets must remain 64 bit");
+static_assert(sizeof(rdb::CompactCheckRecord) <= 32U, "compact check record is too large");
+static_assert(sizeof(rdb::CompactResultRecord) <= 32U, "compact result record is too large");
+static_assert(sizeof(rdb::CompactPropertyRecord) <= 12U, "compact property record is too large");
+
+int main() {
+    rdb::CompactCheckDatabase database;
+    return database.check_count() == 0U ? 0 : 1;
+}

--- a/Parser/rdb_parser_tests.cpp
+++ b/Parser/rdb_parser_tests.cpp
@@ -1,8 +1,10 @@
 #include "ascii_rdb_parser.hpp"
 #include "rdb_check_detail.hpp"
 #include "rdb_check_index.hpp"
+#include "rdb_compact_database.hpp"
 
 #include <cstdlib>
+#include <cstdio>
 #include <fcntl.h>
 #include <iostream>
 #include <stdexcept>
@@ -69,6 +71,30 @@ const rdb::Result& result(const rdb::Database& database,
                           const rdb::RuleCheck& rule_check,
                                    std::size_t index) {
     return database.results[rule_check.results.begin + index];
+}
+
+void expect_store_rejected_unchanged(rdb::CompactCheckDatabase& database,
+                                     rdb::CheckId id,
+                                     const rdb::CheckDetail& detail) {
+    const rdb::CompactMemoryUsage before = database.memory_usage();
+    const std::size_t check_count_before = database.check_count();
+    const std::size_t loaded_before = database.loaded_check_count();
+    const std::uint32_t result_count_before = database.check(id).result_count();
+    const bool detail_loaded_before = database.check(id).detail_loaded();
+    bool rejected = false;
+    try {
+        database.store_detail(id, detail);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    RDB_CHECK(rejected);
+    const rdb::CompactMemoryUsage after = database.memory_usage();
+    RDB_CHECK(after.used_bytes == before.used_bytes);
+    RDB_CHECK(after.capacity_bytes == before.capacity_bytes);
+    RDB_CHECK(database.check_count() == check_count_before);
+    RDB_CHECK(database.loaded_check_count() == loaded_before);
+    RDB_CHECK(database.check(id).detail_loaded() == detail_loaded_before);
+    RDB_CHECK(database.check(id).result_count() == result_count_before);
 }
 
 } // namespace
@@ -162,6 +188,17 @@ int main() {
     RDB_CHECK(index_database.top_cell_name == "TOP_CHIP");
     RDB_CHECK(index_database.database_precision == 1000.0);
     RDB_CHECK(index_database.checks.size() == 3);
+
+    // fd 편의 API는 호출자가 사용 중인 file offset을 변경하지 않는다.
+    const int shared_index_fd = ::open(sample_path("standard_sample.rdb").c_str(), O_RDONLY | O_CLOEXEC);
+    RDB_CHECK(shared_index_fd >= 0);
+    RDB_CHECK(::lseek(shared_index_fd, 7, SEEK_SET) == 7);
+    const rdb::CheckIndexDatabase fd_index_database =
+        index_parser.parse_database(shared_index_fd);
+    RDB_CHECK(fd_index_database.checks.size() == index_database.checks.size());
+    RDB_CHECK(::lseek(shared_index_fd, 0, SEEK_CUR) == 7);
+    RDB_CHECK(::close(shared_index_fd) == 0);
+
     RDB_CHECK(index_database.checks[0].name == "M1.SPACING.1");
     RDB_CHECK(index_database.checks[0].comment ==
         "Rule File Pathname: ./demo.svrf\n"
@@ -520,6 +557,156 @@ int main() {
     RDB_CHECK(!cancelled.completed);
     RDB_CHECK(cancelled.parsed_result_count == 100U);
     RDB_CHECK(delivered_before_cancel == 100U);
+
+    // Fast index와 선택 detail을 Database처럼 flat pool/range 기반 저장소에 합친다.
+    rdb::CompactCheckDatabase compact = rdb::CompactCheckDatabase::from_index(
+        index_parser.parse_database(sample_path("standard_sample.rdb")));
+    RDB_CHECK(compact.top_cell_name().str() == "TOP_CHIP");
+    RDB_CHECK(compact.database_precision() == 1000.0);
+    RDB_CHECK(compact.check_count() == 3U);
+    RDB_CHECK(compact.loaded_check_count() == 0U);
+    RDB_CHECK(compact.check(0).name().str() == "M1.SPACING.1");
+    RDB_CHECK(compact.check(0).offset() == index[0].offset);
+    RDB_CHECK(compact.check(0).result_count() == 2U);
+    RDB_CHECK(!compact.check(0).detail_loaded());
+    RDB_CHECK(compact.find_check_by_offset(index[1].offset) == 1U);
+    RDB_CHECK(compact.find_checks("M2.DENSITY.MIN").size() == 1U);
+
+    bool invalid_check_id_rejected = false;
+    try {
+        (void)compact.check(rdb::invalid_check_id());
+    } catch (const std::out_of_range&) {
+        invalid_check_id_rejected = true;
+    }
+    RDB_CHECK(invalid_check_id_rejected);
+
+    // Every validation failure happens before mutation/reserve and is transactional.
+    rdb::CompactCheckDatabase rollback = rdb::CompactCheckDatabase::from_index(index_database);
+    rdb::CheckDetail mismatched = first_check;
+    mismatched.name = "OTHER.NAME";
+    expect_store_rejected_unchanged(rollback, 0U, mismatched);
+    mismatched = first_check;
+    ++mismatched.offset;
+    expect_store_rejected_unchanged(rollback, 0U, mismatched);
+    mismatched = first_check;
+    --mismatched.current_result_count;
+    mismatched.results.resize(mismatched.current_result_count);
+    expect_store_rejected_unchanged(rollback, 0U, mismatched);
+    mismatched = first_check;
+    mismatched.results[0].kind = rdb::ResultKind::EdgeCluster;
+    expect_store_rejected_unchanged(rollback, 0U, mismatched);
+    mismatched = first_check;
+    mismatched.results[0].kind = static_cast<rdb::ResultKind>(99);
+    expect_store_rejected_unchanged(rollback, 0U, mismatched);
+
+    compact.store_detail(0U, first_check);
+    RDB_CHECK(compact.loaded_check_count() == 1U);
+    const rdb::CompactCheckView stored_check = compact.check(0U);
+    RDB_CHECK(stored_check.detail_loaded());
+    RDB_CHECK(stored_check.executed_at().str() == first_check.executed_at);
+    RDB_CHECK(stored_check.check_text_count() == first_check.check_text.size());
+    RDB_CHECK(stored_check.detail_result_count() == 2U);
+    const rdb::CompactResultView stored_polygon = stored_check.result(0U);
+    RDB_CHECK(stored_polygon.kind() == rdb::ResultKind::Polygon);
+    RDB_CHECK(stored_polygon.ordinal() == 1U);
+    RDB_CHECK(stored_polygon.property_count() == 5U);
+    RDB_CHECK(stored_polygon.property(0U).id().str() == "PP");
+    RDB_CHECK(stored_polygon.property(0U).payload().str() == "M1 spacing marker");
+    RDB_CHECK(stored_polygon.vertex_count() == 4U);
+    RDB_CHECK(stored_polygon.vertex(0U).x == 10000);
+    RDB_CHECK(stored_polygon.edge_count() == 0U);
+    const rdb::CompactResultView stored_edges = stored_check.result(1U);
+    RDB_CHECK(stored_edges.edge_count() == 2U);
+    RDB_CHECK(stored_edges.vertex_count() == 0U);
+
+    const rdb::CompactMemoryUsage compact_memory = compact.memory_usage();
+    RDB_CHECK(compact_memory.used_bytes > 0U);
+    RDB_CHECK(compact_memory.capacity_bytes >= compact_memory.used_bytes);
+    RDB_CHECK(sizeof(rdb::CompactCheckRecord) <= 32U);
+    RDB_CHECK(sizeof(rdb::CompactResultRecord) <= 32U);
+    RDB_CHECK(sizeof(rdb::CompactPropertyRecord) <= 12U);
+
+    bool unloaded_detail_rejected = false;
+    try {
+        (void)compact.check(1U).result(0U);
+    } catch (const std::logic_error&) {
+        unloaded_detail_rejected = true;
+    }
+    RDB_CHECK(unloaded_detail_rejected);
+
+    bool duplicate_detail_rejected = false;
+    try {
+        compact.store_detail(0U, first_check);
+    } catch (const std::logic_error&) {
+        duplicate_detail_rejected = true;
+    }
+    RDB_CHECK(duplicate_detail_rejected);
+
+    const TemporaryRdb duplicate_check_file(
+        "TOP 1000\nDUP.CHECK\n2 2 0 Jul 21 10:35:00 2026\n"
+        "SHARED first-value\np 1 1\n0 0\ne 2 1\n1 2 3 4\n"
+        "DUP.CHECK\n1 1 0 Jul 21 10:36:00 2026\n"
+        "SHARED second-value\np 1 1\n10 20\n");
+    rdb::IndexedRdbFile indexed_file(duplicate_check_file.path());
+    RDB_CHECK(indexed_file.check_count() == 2U);
+    const std::vector<rdb::CheckId> duplicates = indexed_file.find_checks("DUP.CHECK");
+    RDB_CHECK(duplicates.size() == 2U);
+    RDB_CHECK(duplicates[0] == 0U);
+    RDB_CHECK(duplicates[1] == 1U);
+    indexed_file.load_check(duplicates[0]);
+    const rdb::CompactPropertyView first_shared =
+        indexed_file.check(0U).result(0U).property(0U);
+    const rdb::Point copied_point = indexed_file.check(0U).result(0U).vertex(0U);
+    const rdb::Edge copied_edge = indexed_file.check(0U).result(1U).edge(0U);
+    indexed_file.load_check(duplicates[1]);
+    RDB_CHECK(indexed_file.database().loaded_check_count() == 2U);
+    RDB_CHECK(indexed_file.check(0U).result(0U).vertex_count() == 1U);
+    RDB_CHECK(indexed_file.check(0U).result(1U).edge_count() == 1U);
+    RDB_CHECK(first_shared.id().str() == "SHARED");
+    RDB_CHECK(first_shared.payload().str() == "first-value");
+    RDB_CHECK(indexed_file.check(1U).result(0U).property(0U).id().str() == "SHARED");
+    RDB_CHECK(indexed_file.check(1U).result(0U).property(0U).payload().str() == "second-value");
+    RDB_CHECK(copied_point.x == 0 && copied_point.y == 0);
+    RDB_CHECK(copied_edge.first.x == 1 && copied_edge.first.y == 2);
+    RDB_CHECK(copied_edge.second.x == 3 && copied_edge.second.y == 4);
+
+    bool indexed_invalid_id_rejected = false;
+    try {
+        (void)indexed_file.load_check(rdb::invalid_check_id());
+    } catch (const std::out_of_range&) {
+        indexed_invalid_id_rejected = true;
+    }
+    RDB_CHECK(indexed_invalid_id_rejected);
+
+    // Replacing the pathname cannot redirect detail parsing away from the open snapshot.
+    const TemporaryRdb snapshot_file(
+        "TOP 1000\nSNAPSHOT.CHECK\n1 1 0 Jul 21 10:35:00 2026\np 1 1\n7 8\n");
+    rdb::IndexedRdbFile snapshot(snapshot_file.path());
+    const TemporaryRdb replacement_file(
+        "TOP 1000\nREPLACEMENT.CHECK\n1 1 0 Jul 21 10:35:00 2026\np 1 1\n9 9\n");
+    RDB_CHECK(::rename(replacement_file.path().c_str(), snapshot_file.path().c_str()) == 0);
+    const rdb::CompactCheckView snapshot_check = snapshot.load_check(0U);
+    RDB_CHECK(snapshot_check.name().str() == "SNAPSHOT.CHECK");
+    RDB_CHECK(snapshot_check.result(0U).vertex(0U).x == 7);
+    RDB_CHECK(snapshot_check.result(0U).vertex(0U).y == 8);
+
+    // Same-inode writes after construction are rejected before mapped detail access.
+    const TemporaryRdb modified_file(
+        "TOP 1000\nMODIFIED.CHECK\n1 1 0 Jul 21 10:35:00 2026\np 1 1\n1 2\n");
+    rdb::IndexedRdbFile modified(modified_file.path());
+    const int modified_fd = ::open(modified_file.path().c_str(), O_RDWR | O_CLOEXEC);
+    RDB_CHECK(modified_fd >= 0);
+    RDB_CHECK(::pwrite(modified_fd, "X", 1, 0) == 1);
+    RDB_CHECK(::fsync(modified_fd) == 0);
+    RDB_CHECK(::close(modified_fd) == 0);
+    bool modified_rejected = false;
+    try {
+        (void)modified.load_check(0U);
+    } catch (const std::runtime_error&) {
+        modified_rejected = true;
+    }
+    RDB_CHECK(modified_rejected);
+    RDB_CHECK(!modified.check(0U).detail_loaded());
 
     std::cout << "rdb-parser-tests: OK\n";
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,31 @@ ASCII Results Database(RDB)를 읽는 C++11 파서다.
 2. `CheckDetailParser` — index offset에서 선택한 Check만 상세 또는 batch 파싱하며,
    좌표 앞뒤의 property는 `DetailResult::properties`에 발견 순서대로 통합
 
+인덱스와 선택 상세를 작은 flat pool에 함께 보관하려면 `IndexedRdbFile`을 사용한다.
+
+```cpp
+#include "rdb_compact_database.hpp"
+
+rdb::IndexedRdbFile file("results.rdb");
+std::vector<rdb::CheckId> ids = file.find_checks("M1.SPACING.1");
+if (!ids.empty()) {
+    rdb::CompactCheckView check = file.load_check(ids[0]);
+    if (check.detail_result_count() != 0)
+        std::cout << check.result(0).property_count() << " properties\n";
+}
+```
+
+`CompactCheckView`/result/property proxy와 ID는 database가 살아 있는 동안 사용할 수 있다.
+`vertex()`와 `edge()`는 값을 복사해 반환하므로 이후 detail load 뒤에도 반환값이 유효하다.
+단, `TextView`는 내부 byte pool을 빌려 보므로 이후 `load_check()`/`load_all()`이 pool을
+재할당하면 무효화될 수 있다. 문자열이 다시 필요할 때 해당 accessor로 새 view를 얻거나
+`str()`로 복사해야 한다.
+
+메모리를 줄이기 위해 check 이름/offset 검색과 tag-name interning은 보조 hash map 없이
+선형 탐색한다(각각 check 수와 고유 tag-name 수에 대해 O(n)). `memory_usage()`는 compact
+database가 소유한 byte pool/vector의 used/capacity storage만 포함하며 mmap, 객체 자체,
+allocator bookkeeping과 parsing 중 임시 객체는 포함하지 않는다.
+
 ## 빌드와 테스트
 
 ```bash


### PR DESCRIPTION
## Summary
- add `CompactCheckDatabase` with pooled text and flat result/property/geometry storage
- add checked `CompactCheckView`, `CompactResultView`, and `CompactPropertyView` convenience APIs
- add `IndexedRdbFile` to index once and lazily load selected checks from one stable mmap snapshot
- add fd-based FastCheckIndexParser overload without changing the caller file offset
- add transactional validation/rollback, duplicate-name lookup, memory accounting, and load-all helpers

## Memory layout
- `CompactCheckRecord`: <= 32 bytes
- `CompactResultRecord`: <= 32 bytes
- `CompactPropertyRecord`: <= 12 bytes
- 32-bit IDs/ranges/text offsets; 64-bit file offsets

## Verification
- TDD RED observed before implementation
- strict C++11 Release (`-Werror -pedantic-errors`): 3/3 CTests passed
- ASan + UBSan: 3/3 CTests passed
- independent spec review: passed
- independent quality/final review: passed
- synthetic 4.44 MB RDB, 100,000 results: legacy RSS 35,856 KiB vs compact 24,132 KiB (32.7% lower)