### PR TITLE
refactor: unify Result properties

### DIFF
--- a/Parser/ascii_rdb.hpp
+++ b/Parser/ascii_rdb.hpp
@@ -171,12 +171,12 @@ enum class ResultKind : std::uint8_t {
     EdgeCluster  // "e <순번> <edge 수>"
 };
 
-// p/e 결과 하나다. geometry는 실제 좌표를 복사해 담지 않고 전역 배열 구간만 가리킨다.
+// p/e 결과 하나다. property는 좌표 전/사이/후 위치를 구분하지 않고 파일에서 발견한
+// 순서대로 하나의 연속 Range에 저장한다. geometry는 전역 좌표 배열 구간을 가리킨다.
 // kind가 Polygon이면 Database::vertices, EdgeCluster이면 Database::edges를 사용한다.
 struct Result {
-    Range properties_before_geometry;
+    Range properties;
     Range geometry;
-    Range properties_after_geometry;
     StringId signature_suffix;
     std::uint32_t ordinal;
     ResultKind kind;
@@ -208,7 +208,7 @@ struct RuleCheck {
  *
  * RuleCheck::check_text             -> check_text_lines
  * RuleCheck::results                -> results
- * Result::properties_before/after_* -> tagged_values
+ * Result::properties                -> tagged_values
  * Result::geometry                  -> kind에 따라 vertices 또는 edges
  */
 struct Database {

--- a/Parser/ascii_rdb_parser.cpp
+++ b/Parser/ascii_rdb_parser.cpp
@@ -67,6 +67,13 @@ Span content(const LineView& line) {
     return Span(line.data, end);
 }
 
+Span content(const StoredLine& line) {
+    const char* const begin = line.text.data();
+    const char* end = begin + line.text.size();
+    if (end != begin && *(end - 1) == '\r') --end;
+    return Span(begin, end);
+}
+
 bool next_word(Span& input, Span& word) {
     // 문자열을 복사하지 않고 첫 단어를 꺼낸다. input은 다음 단어 앞으로 이동한다.
     input = trim(input);
@@ -583,7 +590,7 @@ private:
         result.ordinal = checked_count(signature.ordinal, signature_line, "result ordinal");
         result.signature_suffix = signature.suffix.empty() ? invalid_string_id() : add_text(database, signature.suffix);
 
-        const Index before_begin = checked_index(database.tagged_values.size(), "property begin");
+        const Index property_begin = checked_index(database.tagged_values.size(), "property begin");
         const Index geometry_begin = signature.kind == ResultKind::Polygon
             ? checked_index(database.vertices.size(), "vertex begin")
             : checked_index(database.edges.size(), "edge begin");
@@ -627,8 +634,9 @@ private:
             append_property(database, text);
         }
 
-        result.properties_before_geometry = Range(
-            before_begin, checked_index(database.tagged_values.size() - before_begin, "property count"));
+        result.properties = Range(
+            property_begin,
+            checked_index(database.tagged_values.size() - property_begin, "property count"));
         result.geometry = Range(
             geometry_begin,
             checked_index(signature.kind == ResultKind::Polygon
@@ -639,9 +647,14 @@ private:
         return result;
     }
 
+    void finish_result_properties(const Database& database, Result& result) {
+        // parse_result()가 기록한 시작점부터 tail에서 추가한 항목까지 하나의 Range로 확장한다.
+        result.properties.count = checked_index(
+            database.tagged_values.size() - result.properties.begin, "property count");
+    }
+
     void consume_nonfinal_result_tail(Database& database, Result& result) {
-        // 다음 p/e 선언 전까지의 태그는 현재 Result의 "좌표 뒤 태그"로 분류한다.
-        const Index after_begin = checked_index(database.tagged_values.size(), "post-property begin");
+        // 다음 p/e 선언 전까지의 태그도 현재 Result의 통합 property Range에 추가한다.
         for (;;) {
             LineView line;
             if (!next_nonblank(line)) fail_at(reader_.position(), 0, "result count exceeds physical result list");
@@ -649,8 +662,7 @@ private:
             if (parse_result_signature(trim(content(line)), next_result)) {
                 // 다음 결과의 선언을 미리 읽었으므로 pending_에 되돌려 다음 호출이 처리하게 한다.
                 push_front(store(line));
-                result.properties_after_geometry = Range(
-                    after_begin, checked_index(database.tagged_values.size() - after_begin, "post-property count"));
+                finish_result_properties(database, result);
                 return;
             }
             if (!options_.allow_properties_after_geometry) {
@@ -662,12 +674,10 @@ private:
 
     void consume_final_result_tail(Database& database, Result& result) {
         // 마지막 결과는 다음 Result가 아닌 다음 RuleCheck를 만나야 경계가 끝난다.
-        const Index after_begin = checked_index(database.tagged_values.size(), "post-property begin");
         for (;;) {
             LineView candidate_line;
             if (!next_nonblank(candidate_line)) {
-                result.properties_after_geometry = Range(
-                    after_begin, checked_index(database.tagged_values.size() - after_begin, "post-property count"));
+                finish_result_properties(database, result);
                 return;
             }
 
@@ -682,9 +692,8 @@ private:
                 if (!options_.allow_properties_after_geometry) {
                     fail(candidate_line, "unexpected line after final result geometry");
                 }
-                append_property(database, trim(content(candidate_line)));
-                result.properties_after_geometry = Range(
-                    after_begin, checked_index(database.tagged_values.size() - after_begin, "post-property count"));
+                append_property(database, trim(content(candidate)));
+                finish_result_properties(database, result);
                 return;
             }
 
@@ -692,8 +701,7 @@ private:
             if (parse_rule_header(trim(content(possible_header_line)), possible_header)) {
                 // 후보 이름 + 헤더 조합이 확인되면 다음 RuleCheck용으로 두 줄을 되돌린다.
                 push_rule_boundary(candidate, store(possible_header_line));
-                result.properties_after_geometry = Range(
-                    after_begin, checked_index(database.tagged_values.size() - after_begin, "post-property count"));
+                finish_result_properties(database, result);
                 return;
             }
 
@@ -701,7 +709,7 @@ private:
                 fail(candidate_line, "expected next rule-check header");
             }
 
-            append_property(database, trim(content(candidate_line)));
+            append_property(database, trim(content(candidate)));
             push_front(store(possible_header_line));
         }
     }

--- a/Parser/rdb_parser_tests.cpp
+++ b/Parser/rdb_parser_tests.cpp
@@ -121,24 +121,71 @@ int main() {
     RDB_CHECK(rule(standard, 0).results.count == 2);
     RDB_CHECK(result(standard, rule(standard, 0), 0).kind == rdb::ResultKind::Polygon);
     RDB_CHECK(result(standard, rule(standard, 0), 0).geometry.count == 4);
-    RDB_CHECK(result(standard, rule(standard, 0), 0).properties_before_geometry.count == 5);
+    RDB_CHECK(result(standard, rule(standard, 0), 0).properties.count == 5);
     RDB_CHECK(text(standard, standard.tagged_values[
-        result(standard, rule(standard, 0), 0).properties_before_geometry.begin].id) == "PP");
+        result(standard, rule(standard, 0), 0).properties.begin].id) == "PP");
     RDB_CHECK(text(standard, standard.tagged_values[
-        result(standard, rule(standard, 0), 0).properties_before_geometry.begin].payload) == "M1 spacing marker");
+        result(standard, rule(standard, 0), 0).properties.begin].payload) == "M1 spacing marker");
     RDB_CHECK(standard.vertices[0].x == 10000);
     RDB_CHECK(standard.vertices[0].y == 20000);
     RDB_CHECK(result(standard, rule(standard, 0), 1).kind == rdb::ResultKind::EdgeCluster);
     RDB_CHECK(result(standard, rule(standard, 0), 1).geometry.count == 2);
-    RDB_CHECK(result(standard, rule(standard, 1), 0).properties_before_geometry.count == 2);
+    RDB_CHECK(result(standard, rule(standard, 1), 0).properties.count == 2);
     RDB_CHECK(rule(standard, 2).results.empty());
 
     const rdb::Database post_geometry =
         parser.parse_file(sample_path("post_coordinate_tags_sample.rdb"));
     RDB_CHECK(post_geometry.rule_checks.size() == 1);
     RDB_CHECK(rule(post_geometry, 0).results.count == 2);
-    RDB_CHECK(result(post_geometry, rule(post_geometry, 0), 0).properties_after_geometry.count == 2);
-    RDB_CHECK(result(post_geometry, rule(post_geometry, 0), 1).properties_after_geometry.count == 3);
+    RDB_CHECK(result(post_geometry, rule(post_geometry, 0), 0).properties.count == 2);
+    RDB_CHECK(result(post_geometry, rule(post_geometry, 0), 1).properties.count == 3);
+
+    // Full Database Result도 좌표 전/사이/후 property를 발견 순서대로 하나의 Range에 보관한다.
+    const TemporaryRdb mixed_full_property_file(
+        "TOP 1000\nMIXED.FULL.PROPERTIES\n1 1 0 Jul 21 10:35:00 2026\n"
+        "p 1 2\nPB before geometry\n0 0\nPM between coordinates\n1 1\nPA after geometry\n");
+    const rdb::Database mixed_full_properties =
+        parser.parse_file(mixed_full_property_file.path());
+    const rdb::Result& mixed_full_result =
+        result(mixed_full_properties, rule(mixed_full_properties, 0), 0);
+    RDB_CHECK(mixed_full_result.properties.count == 3U);
+    const rdb::Index mixed_property_begin = mixed_full_result.properties.begin;
+    RDB_CHECK(text(mixed_full_properties,
+                   mixed_full_properties.tagged_values[mixed_property_begin].id) == "PB");
+    RDB_CHECK(text(mixed_full_properties,
+                   mixed_full_properties.tagged_values[mixed_property_begin].payload) ==
+              "before geometry");
+    RDB_CHECK(text(mixed_full_properties,
+                   mixed_full_properties.tagged_values[mixed_property_begin + 1U].id) == "PM");
+    RDB_CHECK(text(mixed_full_properties,
+                   mixed_full_properties.tagged_values[mixed_property_begin + 2U].id) == "PA");
+    RDB_CHECK(text(mixed_full_properties,
+                   mixed_full_properties.tagged_values[mixed_property_begin + 2U].payload) ==
+              "after geometry");
+
+    // Final tail lookahead가 reader buffer를 교체해도 property 원문과 순서를 보존해야 한다.
+    const std::string long_tail_payload(200U, 'x');
+    const TemporaryRdb overflow_tail_file(
+        std::string("TOP 1000\nOVERFLOW.TAIL\n1 1 0 Jul 21 10:35:00 2026\n") +
+        "p 1 1\n0 0\nXL " + long_tail_payload + "\nLAST final-value");
+    rdb::ParseOptions overflow_tail_options;
+    overflow_tail_options.read_buffer_bytes = 17U;
+    const rdb::Database overflow_tail =
+        parser.parse_file(overflow_tail_file.path(), overflow_tail_options);
+    const rdb::Result& overflow_tail_result =
+        result(overflow_tail, rule(overflow_tail, 0), 0);
+    RDB_CHECK(overflow_tail_result.properties.count == 2U);
+    const rdb::Index overflow_property_begin = overflow_tail_result.properties.begin;
+    RDB_CHECK(text(overflow_tail,
+                   overflow_tail.tagged_values[overflow_property_begin].id) == "XL");
+    RDB_CHECK(text(overflow_tail,
+                   overflow_tail.tagged_values[overflow_property_begin].payload) ==
+              long_tail_payload);
+    RDB_CHECK(text(overflow_tail,
+                   overflow_tail.tagged_values[overflow_property_begin + 1U].id) == "LAST");
+    RDB_CHECK(text(overflow_tail,
+                   overflow_tail.tagged_values[overflow_property_begin + 1U].payload) ==
+              "final-value");
 
     const rdb::Database large_standard =
         parser.parse_file(sample_path("large_standard_sample.rdb"));

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ ASCII Results Database(RDB)를 읽는 C++11 파서다.
 대용량 RDB의 Check 탐색에는 다음 두 파서를 사용한다.
 
 1. `FastCheckIndexParser` — Check 이름, Result 수, comment, 파일 offset 인덱싱
-2. `CheckDetailParser` — index offset에서 선택한 Check만 상세 또는 batch 파싱하며,
-   좌표 앞뒤의 property는 `DetailResult::properties`에 발견 순서대로 통합
+2. `CheckDetailParser` — index offset에서 선택한 Check만 상세 또는 batch 파싱
+
+전체 파서의 `Result::properties`와 선택 상세의 `DetailResult::properties`는 모두 좌표 전,
+좌표 사이, 좌표 뒤 Property를 위치별로 분리하지 않고 파일에서 발견한 순서대로 통합한다.
 
 인덱스와 선택 상세를 작은 flat pool에 함께 보관하려면 `IndexedRdbFile`을 사용한다.
 


### PR DESCRIPTION
## Summary
- replace `Result::properties_before_geometry` and `Result::properties_after_geometry` with one `Result::properties` range
- preserve properties encountered before, between, and after coordinates in file order
- document the unified full/detail API
- fix final-tail lookahead to consume the owned line copy after reader refill

## Verification
- TDD compile RED for missing `Result::properties`
- mixed before/between/after order fixture
- small-buffer long-tail and no-final-newline regression fixture
- strict Release: 5/5 passed
- ASan + leak detection: 5/5 passed
- UBSan: 5/5 passed
- independent review: passed