### PR TITLE
docs: add Check tagged key lookup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ if (!ids.empty()) {
 }
 ```
 
+전체 예시의 `tagged_keys(database, loaded)` 함수는 Check에 속한 모든 Result의
+`TaggedValue::id`만 `StringId`로 모은다. 문자열을 복사하지 않고 파일 등장 순서와
+중복 key를 유지하며, 실제 key 문자열은 `database.strings.get(id)`로 조회한다.
+
 `load_check()`는 동일 Check에 대해 idempotent하며, `load_all()`은 모든 Check를 같은
 `Database`에 완성한다. Result가 0개인 Check도 `detail_loaded`로 index-only 상태와
 구분한다.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,6 +17,17 @@ if(BUILD_TESTING)
     )
 
     add_test(
+        NAME rdb-database-example-tagged-keys
+        COMMAND rdb-database-example
+            "${CMAKE_CURRENT_SOURCE_DIR}/../standard_sample.rdb"
+            "M1.SPACING.1"
+    )
+    set_tests_properties(rdb-database-example-tagged-keys PROPERTIES
+        PASS_REGULAR_EXPRESSION
+            "Tagged keys: PP PA EL EW CN"
+    )
+
+    add_test(
         NAME rdb-database-example-missing-check
         COMMAND "${CMAKE_COMMAND}"
             "-DEXAMPLE=$<TARGET_FILE:rdb-database-example>"

--- a/examples/rdb_database_example.cpp
+++ b/examples/rdb_database_example.cpp
@@ -5,6 +5,8 @@
 #include <exception>
 #include <iomanip>
 #include <iostream>
+#include <limits>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -26,6 +28,32 @@ struct TraversalTotals {
 
 std::string text(const rdb::Database& database, rdb::StringId id) {
     return database.strings.get(id).str();
+}
+
+// Check의 모든 Result에서 Tagged key(StringId)만 빠르게 모은다.
+// 파일의 등장 순서를 유지하고 중복 key도 유지하며, 문자열 바이트는 복사하지 않는다.
+std::vector<rdb::StringId> tagged_keys(
+    const rdb::Database& database,
+    const rdb::RuleCheck& check) {
+    std::size_t property_count = 0;
+    for (rdb::Index i = 0; i < check.results.count; ++i) {
+        const rdb::Result& result = database.results[check.results.begin + i];
+        if (result.properties.count >
+            std::numeric_limits<std::size_t>::max() - property_count) {
+            throw std::length_error("tagged key count exceeds size_t capacity");
+        }
+        property_count += result.properties.count;
+    }
+
+    std::vector<rdb::StringId> keys;
+    keys.reserve(property_count);
+    for (rdb::Index i = 0; i < check.results.count; ++i) {
+        const rdb::Result& result = database.results[check.results.begin + i];
+        for (rdb::Index j = 0; j < result.properties.count; ++j) {
+            keys.push_back(database.tagged_values[result.properties.begin + j].id);
+        }
+    }
+    return keys;
 }
 
 TraversalTotals traverse(const rdb::Database& database, const rdb::RuleCheck& check) {
@@ -136,6 +164,13 @@ int main(int argc, char** argv) {
         file.load_check(selected_id);
         const rdb::RuleCheck& loaded = database.check(selected_id);
         const TraversalTotals totals = traverse(database, loaded);
+        const std::vector<rdb::StringId> keys = tagged_keys(database, loaded);
+
+        std::cout << "Tagged keys:";
+        for (std::size_t i = 0; i < keys.size(); ++i) {
+            std::cout << ' ' << text(database, keys[i]);
+        }
+        std::cout << '\n';
 
         std::cout << "Check: " << text(database, loaded.name)
                   << " | Results: " << loaded.results.count


### PR DESCRIPTION
## Summary
- add `tagged_keys(database, check)` to collect TaggedValue key StringIds across all Results of a loaded Check
- preserve encounter order and duplicate keys without copying string bytes
- print the resolved keys in the runnable example
- add a CTest output contract and README explanation

## Verification
- strict Release: 6/6 passed
- ASan + leak detection: 6/6 passed
- UBSan: 6/6 passed
- independent review: passed