### PR TITLE
feat(rdb): support indexed file copy and replacement

### DIFF
--- a/Parser/CMakeLists.txt
+++ b/Parser/CMakeLists.txt
@@ -7,6 +7,8 @@ target_compile_options(rdb_indexed_file PRIVATE
 )
 
 if(BUILD_TESTING)
+    find_package(Threads REQUIRED)
+
     add_executable(rdb-parser-tests rdb_parser_tests.cpp)
     target_link_libraries(rdb-parser-tests PRIVATE rdb_indexed_file)
     target_compile_options(rdb-parser-tests PRIVATE
@@ -22,7 +24,7 @@ if(BUILD_TESTING)
     add_test(NAME rdb-check-index-header-test COMMAND rdb-check-index-header-test)
 
     add_executable(rdb-unified-database-test rdb_unified_database_test.cpp)
-    target_link_libraries(rdb-unified-database-test PRIVATE rdb_indexed_file)
+    target_link_libraries(rdb-unified-database-test PRIVATE rdb_indexed_file Threads::Threads)
     target_compile_options(rdb-unified-database-test PRIVATE
         $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall;-Wextra;-Wpedantic;-Werror>
     )

--- a/Parser/ascii_rdb.hpp
+++ b/Parser/ascii_rdb.hpp
@@ -164,6 +164,15 @@ public:
         ++epoch_;
     }
 
+    void swap(StringTable& other) noexcept {
+        records_.swap(other.records_);
+        bytes_.swap(other.bytes_);
+        // Checkpoints are bound to an object's previous contents, so swapping
+        // invalidates checkpoints from both tables instead of swapping epochs.
+        ++epoch_;
+        ++other.epoch_;
+    }
+
     void clear() { records_.clear(); bytes_.clear(); ++epoch_; }
 
 private:

--- a/Parser/rdb_indexed_file.cpp
+++ b/Parser/rdb_indexed_file.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <limits>
 #include <stdexcept>
+#include <utility>
 
 namespace rdb {
 namespace {
@@ -258,15 +259,37 @@ void store_detail(Database& database,
 } // namespace
 
 IndexedRdbFile::IndexedRdbFile(const std::string& path, const FastCheckIndexOptions& options)
-    : file_(path),
-      file_state_(file_.state()),
+    : file_(std::make_shared<detail::MappedFile>(path)),
+      file_state_(file_->state()),
       database_(database_from_index(
-          FastCheckIndexParser().parse_database(file_.descriptor(), options))) {
+          FastCheckIndexParser().parse_database(file_->descriptor(), options))) {
     verify_file_unchanged();
 }
 
+IndexedRdbFile& IndexedRdbFile::operator=(IndexedRdbFile other) noexcept {
+    swap(other);
+    return *this;
+}
+
+void IndexedRdbFile::swap(IndexedRdbFile& other) noexcept {
+    file_.swap(other.file_);
+    using std::swap;
+    swap(file_state_, other.file_state_);
+    database_.strings.swap(other.database_.strings);
+    swap(database_.top_cell_name, other.database_.top_cell_name);
+    swap(database_.database_precision, other.database_.database_precision);
+    database_.rule_checks.swap(other.database_.rule_checks);
+    database_.results.swap(other.database_.results);
+    database_.vertices.swap(other.database_.vertices);
+    database_.edges.swap(other.database_.edges);
+    database_.tagged_values.swap(other.database_.tagged_values);
+    database_.check_text_lines.swap(other.database_.check_text_lines);
+    swap(database_.loaded_rule_check_count, other.database_.loaded_rule_check_count);
+    tag_names_.swap(other.tag_names_);
+}
+
 void IndexedRdbFile::verify_file_unchanged() {
-    const detail::FileState current = file_.state();
+    const detail::FileState current = file_->state();
     if (detail::same_file_snapshot(file_state_, current)) return;
     if (detail::same_file_after_path_replacement(file_state_, current)) {
         file_state_ = current;
@@ -279,7 +302,7 @@ const RuleCheck& IndexedRdbFile::load_check(CheckId id) {
     verify_file_unchanged();
     const RuleCheck& selected = database_.check(id);
     if (!selected.detail_loaded) {
-        const CheckDetail detail = detail::parse_check_detail(file_, selected.offset);
+        const CheckDetail detail = detail::parse_check_detail(*file_, selected.offset);
         verify_file_unchanged();
         store_detail(database_, tag_names_, id, detail);
     }

--- a/Parser/rdb_indexed_file.hpp
+++ b/Parser/rdb_indexed_file.hpp
@@ -4,6 +4,7 @@
 #include "rdb_check_detail.hpp"
 
 #include <cstddef>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -16,6 +17,13 @@ public:
     explicit IndexedRdbFile(
         const std::string& path,
         const FastCheckIndexOptions& options = FastCheckIndexOptions());
+    IndexedRdbFile(const IndexedRdbFile&) = default;
+    IndexedRdbFile(IndexedRdbFile&&) noexcept = default;
+
+    // Copy assignment deep-copies Database/parser state. Passing an rvalue moves
+    // the fully parsed pools, which is the efficient worker-thread replacement path.
+    IndexedRdbFile& operator=(IndexedRdbFile other) noexcept;
+    void swap(IndexedRdbFile& other) noexcept;
 
     const Database& database() const { return database_; }
     std::size_t check_count() const { return database_.check_count(); }
@@ -28,11 +36,11 @@ public:
     void load_all();
 
 private:
-    IndexedRdbFile(const IndexedRdbFile&);
-    IndexedRdbFile& operator=(const IndexedRdbFile&);
     void verify_file_unchanged();
 
-    detail::MappedFile file_;
+    // Copies share the same open inode/mmap lifetime while Database state is deep-copied.
+    // The backing inode must not be modified in place while any copy may parse it.
+    std::shared_ptr<detail::MappedFile> file_;
     detail::FileState file_state_;
     Database database_;
     // Property tag interning is parser-session state, not canonical Database data.

--- a/Parser/rdb_unified_database_test.cpp
+++ b/Parser/rdb_unified_database_test.cpp
@@ -3,6 +3,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <fcntl.h>
+#include <future>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -67,6 +68,18 @@ int main() {
         std::is_same<decltype(std::declval<const rdb::IndexedRdbFile&>().database()),
                      const rdb::Database&>::value,
         "IndexedRdbFile must expose the canonical Database as read-only state");
+    static_assert(std::is_copy_constructible<rdb::IndexedRdbFile>::value,
+                  "IndexedRdbFile must support independent copy construction");
+    static_assert(std::is_copy_assignable<rdb::IndexedRdbFile>::value,
+                  "IndexedRdbFile must support independent copy assignment");
+    static_assert(std::is_move_constructible<rdb::IndexedRdbFile>::value,
+                  "IndexedRdbFile must support efficient ownership transfer");
+    static_assert(std::is_move_assignable<rdb::IndexedRdbFile>::value,
+                  "IndexedRdbFile must support efficient parsed-state replacement");
+    static_assert(std::is_nothrow_move_constructible<rdb::IndexedRdbFile>::value,
+                  "IndexedRdbFile move construction must not copy parsed pools");
+    static_assert(std::is_nothrow_move_assignable<rdb::IndexedRdbFile>::value,
+                  "IndexedRdbFile move assignment must not copy parsed pools");
 
     rdb::StringTable checkpoint_table;
     checkpoint_table.add("kept", 4U);
@@ -93,6 +106,30 @@ int main() {
         stale_checkpoint_rejected = true;
     }
     RDB_CHECK(stale_checkpoint_rejected);
+
+    rdb::StringTable swap_left;
+    rdb::StringTable swap_right;
+    swap_left.add("left", 4U);
+    swap_right.add("right", 5U);
+    const rdb::StringTable::Checkpoint left_pre_swap_checkpoint = swap_left.checkpoint();
+    const rdb::StringTable::Checkpoint right_pre_swap_checkpoint = swap_right.checkpoint();
+    swap_left.swap(swap_right);
+    RDB_CHECK(swap_left.get(0U).str() == "right");
+    RDB_CHECK(swap_right.get(0U).str() == "left");
+    bool pre_swap_checkpoint_rejected = false;
+    try {
+        swap_left.rollback(left_pre_swap_checkpoint);
+    } catch (const std::out_of_range&) {
+        pre_swap_checkpoint_rejected = true;
+    }
+    RDB_CHECK(pre_swap_checkpoint_rejected);
+    bool right_pre_swap_checkpoint_rejected = false;
+    try {
+        swap_right.rollback(right_pre_swap_checkpoint);
+    } catch (const std::out_of_range&) {
+        right_pre_swap_checkpoint_rejected = true;
+    }
+    RDB_CHECK(right_pre_swap_checkpoint_rejected);
 
     const std::string path = std::string(RDB_SAMPLE_DIR) + "/standard_sample.rdb";
     rdb::IndexedRdbFile file(path);
@@ -167,6 +204,85 @@ int main() {
     RDB_CHECK(all_file.database().check(2U).results.count == 0U);
     all_file.load_all();
     RDB_CHECK(all_file.database().loaded_check_count() == 3U);
+
+    // Copies share only the immutable open-file snapshot. Their canonical Database
+    // and parser-session tag state remain independent while lazy loading continues.
+    rdb::IndexedRdbFile copy_source(path);
+    copy_source.load_check(0U);
+    rdb::IndexedRdbFile copy_constructed(copy_source);
+    copy_constructed.load_check(1U);
+    RDB_CHECK(copy_source.database().loaded_check_count() == 1U);
+    RDB_CHECK(copy_constructed.database().loaded_check_count() == 2U);
+    RDB_CHECK(!copy_source.database().check(1U).detail_loaded);
+    RDB_CHECK(copy_constructed.database().check(1U).detail_loaded);
+
+    // Assignment replaces both Database contents and the backing file snapshot.
+    // The assigned copy must remain usable after the source object is destroyed.
+    const TemporaryRdb assignment_initial("ASSIGNMENT_OLD 1000\n");
+    rdb::IndexedRdbFile assigned(assignment_initial.path());
+    {
+        rdb::IndexedRdbFile assignment_source(path);
+        assignment_source.load_check(0U);
+        assigned = assignment_source;
+        assignment_source = assignment_source;
+        RDB_CHECK(assignment_source.database().loaded_check_count() == 1U);
+        assigned.load_check(1U);
+        RDB_CHECK(assigned.database().loaded_check_count() == 2U);
+        RDB_CHECK(!assignment_source.database().check(1U).detail_loaded);
+        assignment_source.load_check(2U);
+        RDB_CHECK(assignment_source.database().check(2U).detail_loaded);
+        RDB_CHECK(!assigned.database().check(2U).detail_loaded);
+    }
+    RDB_CHECK(text(assigned.database(), assigned.database().top_cell_name) == "TOP_CHIP");
+    RDB_CHECK(assigned.database().loaded_check_count() == 2U);
+
+    const TemporaryRdb copied_snapshot_source(
+        "COPY_SNAPSHOT 1000\nCOPY.ONE\n0 0 0 Jul 21 10:35:00 2026\n"
+        "COPY.TWO\n1 1 0 Jul 21 10:36:00 2026\np 1 1\n11 12\n");
+    const TemporaryRdb copied_snapshot_initial("COPY_OLD 1000\n");
+    rdb::IndexedRdbFile copied_snapshot(copied_snapshot_initial.path());
+    {
+        rdb::IndexedRdbFile snapshot_source(copied_snapshot_source.path());
+        copied_snapshot = snapshot_source;
+    }
+    RDB_CHECK(::unlink(copied_snapshot_source.path().c_str()) == 0);
+    copied_snapshot.load_check(1U);
+    const rdb::RuleCheck& copied_snapshot_check = copied_snapshot.database().check(1U);
+    const rdb::Result& copied_snapshot_result =
+        copied_snapshot.database().results[copied_snapshot_check.results.begin];
+    RDB_CHECK(copied_snapshot.database().vertices[copied_snapshot_result.geometry.begin].x == 11);
+    RDB_CHECK(copied_snapshot.database().vertices[copied_snapshot_result.geometry.begin].y == 12);
+
+    // Intended workflow: parse every Check on a worker thread, then replace the
+    // foreground object with an O(1) move assignment after synchronization.
+    std::future<rdb::IndexedRdbFile> full_parse = std::async(
+        std::launch::async,
+        [path]() {
+            rdb::IndexedRdbFile parsed(path);
+            parsed.load_all();
+            return parsed;
+        });
+    const TemporaryRdb foreground_initial("FOREGROUND_OLD 1000\n");
+    rdb::IndexedRdbFile foreground(foreground_initial.path());
+    rdb::IndexedRdbFile parsed = full_parse.get();
+    const rdb::Result* const parsed_results = parsed.database().results.data();
+    const rdb::Point* const parsed_vertices = parsed.database().vertices.data();
+    const rdb::Edge* const parsed_edges = parsed.database().edges.data();
+    const rdb::TaggedValue* const parsed_properties = parsed.database().tagged_values.data();
+    const rdb::StringId* const parsed_check_text = parsed.database().check_text_lines.data();
+    const char* const parsed_top_cell =
+        parsed.database().strings.get(parsed.database().top_cell_name).data;
+    foreground = std::move(parsed);
+    RDB_CHECK(text(foreground.database(), foreground.database().top_cell_name) == "TOP_CHIP");
+    RDB_CHECK(foreground.database().loaded_check_count() == foreground.database().check_count());
+    RDB_CHECK(foreground.database().results.size() == all_file.database().results.size());
+    RDB_CHECK(foreground.database().results.data() == parsed_results);
+    RDB_CHECK(foreground.database().vertices.data() == parsed_vertices);
+    RDB_CHECK(foreground.database().edges.data() == parsed_edges);
+    RDB_CHECK(foreground.database().tagged_values.data() == parsed_properties);
+    RDB_CHECK(foreground.database().check_text_lines.data() == parsed_check_text);
+    RDB_CHECK(foreground.database().strings.get(foreground.database().top_cell_name).data ==
+              parsed_top_cell);
 
     const TemporaryRdb decimal_header("TOP_DECIMAL 1.25e-3\n");
     const rdb::IndexedRdbFile indexed_decimal(decimal_header.path());

--- a/README.md
+++ b/README.md
@@ -74,6 +74,43 @@ if (!ids.empty()) {
 `Database`에 완성한다. Result가 0개인 Check도 `detail_loaded`로 index-only 상태와
 구분한다.
 
+## 백그라운드 full parse 후 교체
+
+`IndexedRdbFile` 복사는 같은 open inode와 mmap 수명만 공유하고 `Database`와 tag parser
+상태는 독립적으로 깊은 복사한다. 따라서 복사가 완료된 뒤 서로 다른 복사본에서
+`load_check()`를 호출해도 상대 복사본의 Database는 변경되지 않는다.
+
+전체 파싱 결과를 전면 객체로 교체할 때는 복사 대입도 가능하지만, 대용량 pool을 다시 복사하지
+않도록 worker 결과를 **move 대입**하는 것이 권장된다.
+
+```cpp
+#include <future>
+
+std::future<rdb::IndexedRdbFile> pending = std::async(
+    std::launch::async,
+    []() {
+        rdb::IndexedRdbFile parsed("results.rdb");
+        parsed.load_all();
+        return parsed;
+    });
+
+// UI/foreground thread에서 기존 index-only 객체를 계속 사용한다.
+rdb::IndexedRdbFile active("results.rdb");
+
+// worker 완료 후 foreground reader가 없는 동기화 지점에서 O(1)로 교체한다.
+active = pending.get();
+```
+
+`IndexedRdbFile`은 내부 동기화를 제공하지 않는다. 같은 인스턴스의 `load_check()`/`load_all()`/
+대입/swap과 read/copy/move를 겹치면 data race이므로 외부에서 동기화해야 한다. 복사가 완료된
+서로 다른 인스턴스는 독립적으로 lazy load할 수 있다. worker 완료를 기다린 뒤 mutex,
+event-loop handoff 등으로 기존 reader가 없는 시점에 교체해야 하며, 대입하면 기존
+`database()`에서 얻은 참조·포인터·iterator는 모두 무효화된다.
+
+공유 mmap은 파일 바이트를 별도 복제한 immutable snapshot이 아니다. lazy parse가 끝날 때까지
+backing inode를 제자리 수정하거나 truncate하면 안 된다. pathname 갱신은 기존 inode를 건드리지
+않는 rename 기반 원자 교체를 사용해야 한다.
+
 ## 수명과 순서
 
 - `CheckId`는 `Database::rule_checks`의 index이며 파일 순서대로 고정된다.


### PR DESCRIPTION
## Summary
- add independent copy construction and strong copy assignment for `IndexedRdbFile`
- share only the open inode/mmap lifetime while deep-copying canonical Database and parser state
- add noexcept O(1) move replacement for worker-thread full parse handoff
- document external synchronization and backing-inode constraints

## Tests
- strict Release CTest: 6/6
- ASan + leak detection: 6/6
- UBSan: 6/6
- copy independence, source destruction/unlink lifetime, self-assignment, and async full-parse move replacement covered
- independent pre-commit review passed